### PR TITLE
Federicor/update templates

### DIFF
--- a/solution/tc_project_app/POUs/Application_Specific/Applications/Shutter_Operator_panel_Template.TcPOU
+++ b/solution/tc_project_app/POUs/Application_Specific/Applications/Shutter_Operator_panel_Template.TcPOU
@@ -3,13 +3,18 @@
   <POU Name="Shutter_Operator_panel_Template" Id="{09741edf-58a0-0d9d-0563-de91fec8904d}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM Shutter_Operator_panel_Template
 VAR
-    //Variables used to control the LEDs of the Safety Shutter Operator panel
-    (*bExtendedLight AT %Q*: BOOL; //Power output for Open position + LED
+    (*//Variables used to control the LEDs of the Safety Shutter Operator panel
+    {attribute 'TcLinkTo' := 'TIID^Device 1 (EtherCAT)^KF201 (EK1200)^KF217 (EK1521)^KF01 (EK1501-0100)^KF03 (EL2014)^DIG Outputs^Channel 1^Output'}
+    bExtendedLight AT %Q*: BOOL; //Power output for Open position + LED
+    {attribute 'TcLinkTo' := 'TIID^Device 1 (EtherCAT)^KF201 (EK1200)^KF217 (EK1521)^KF01 (EK1501-0100)^KF03 (EL2014)^DIG Outputs^Channel 3^Output'}
     bRetractedLight AT %Q*: BOOL; //Power output for Close position + LED
+    {attribute 'TcLinkTo' := 'TIID^Device 1 (EtherCAT)^KF201 (EK1200)^KF217 (EK1521)^KF01 (EK1501-0100)^KF03 (EL2014)^DIG Outputs^Channel 2^Output'}
     bMovingLight AT %Q*: BOOL; //Power output for cylinder Moving LED
+    {attribute 'TcLinkTo' := 'TIID^Device 1 (EtherCAT)^KF201 (EK1200)^KF217 (EK1521)^KF01 (EK1501-0100)^KF04 (EL2014)^DIG Outputs^Channel 1^Output'}
     bNoPermitLight AT %Q*: BOOL; //Power output for No permit LED
+    {attribute 'TcLinkTo' := 'TIID^Device 1 (EtherCAT)^KF201 (EK1200)^KF217 (EK1521)^KF01 (EK1501-0100)^KF04 (EL2014)^DIG Outputs^Channel 2^Output'}
     bErrorLight AT %Q*: BOOL; //Power output for Error LED
-    *)
+*)
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/solution/tc_project_app/POUs/Application_Specific/Axes/Pneumatics_Template.TcPOU
+++ b/solution/tc_project_app/POUs/Application_Specific/Axes/Pneumatics_Template.TcPOU
@@ -9,14 +9,13 @@ END_VAR
     <Implementation>
       <ST><![CDATA[//Initial parameters of an Pneumatic Axis
 //Uncomment the next IF statement to configure and activate the intial parameters of the axis
-(*IF TaskInfo[fbGetCurTaskIndex.index].FirstCycle THEN
+(*
+IF TaskInfo[fbGetCurTaskIndex.index].FirstCycle THEN
     GVL.astPneumaticAxes[x].stPneumaticAxisConfig.sPneumaticAxisName := 'Shutter';
-    GVL.astPneumaticAxes[x].stPneumaticAxisConfig.bPneumaticAxisShutter := TRUE;
+    GVL.astPneumaticAxes[x].stPneumaticAxisConfig.bSafetyShutter := TRUE;
     GVL.astPneumaticAxes[x].stPneumaticAxisConfig.nTimeToExtend := 10;
     GVL.astPneumaticAxes[x].stPneumaticAxisConfig.nTimeToRetract := 10;
     GVL.astPneumaticAxes[x].stPneumaticAxisConfig.nAllowTimePressureOutOfRange := 5;
-    GVL.astPneumaticAxes[x].stPneumaticAxisConfig.fLowLimitPressureValue := 3.5;
-    GVL.astPneumaticAxes[x].stPneumaticAxisConfig.fHighLimitPressureValue := 6.0;
 END_IF
 *)
 


### PR DESCRIPTION
- The shutter OP template now has attributes over the LEDs outputs. TcLinkTo to have direct linking for the LEDs of the shutter OP.
- The pneumatics template was updated to reflect the renaming to bSafetyShutter and moving the pressure limits to GVL