### PR TITLE
Federicor/update gvlapp and template

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -18,6 +18,12 @@ which will reset the third digit to 0.
 The 3rd digit will be increased, when there is a pure bugfix.
 See v2.0.0 vs 2.0.1
 
+v2.9.1
+- Compatible with tc_mca_std_lib v2.9.0
+- Improvements:
+  - Change the ENUMs in the GVL_APP and in the Axis_template from just the simple integer
+    value, to the explicit variable name to make the code easier to understand.
+
 v2.9.0
 - Compatible with tc_mca_std_lib v2.9.0
 - New features:

--- a/solution/tc_project_app/GVLs/GVL_APP.TcGVL
+++ b/solution/tc_project_app/GVLs/GVL_APP.TcGVL
@@ -4,7 +4,7 @@
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL
     //Defines the CPU type: 0 for CX5130 and 1 for c6017-0020
-    eCPUType: E_CPUType; //:= 1;
+    eCPUType: E_CPUType; //:= E_CPUType.C6017_0020;
 END_VAR
 
 VAR_GLOBAL CONSTANT

--- a/solution/tc_project_app/POUs/Application_Specific/Axes/Axis_Template.TcPOU
+++ b/solution/tc_project_app/POUs/Application_Specific/Axes/Axis_Template.TcPOU
@@ -18,7 +18,7 @@ END_VAR
 (*
 IF _TaskInfo[fbGetCurTaskIndex.index].FirstCycle THEN
     //Initial default values:
-    GVL.astAxes[x].stConfig.eHomeSeq := 0;
+    GVL.astAxes[x].stConfig.eHomeSeq := E_HomingRoutines.eNoHoming;
     GVL.astAxes[x].stConfig.fHomePosition := 0.0;
     GVL.astAxes[x].stConfig.fHomeFinishDistance := 0.0;
     GVL.astAxes[x].stConfig.eRestorePosition := E_RestorePosition.eRestoreWithoutHome;
@@ -29,14 +29,14 @@ IF _TaskInfo[fbGetCurTaskIndex.index].FirstCycle THEN
     GVL.astAxes[x].stConfig.bAutoDisable := FALSE;
 
     //Brake and Airpads
-    GVL.astAxes[x].stConfig.stAirpadBrake.bExternalBrakeConnected := FALSE;
-    GVL.astAxes[x].stConfig.stAirpadBrake.bExternalBrakeFeedbackConnected := FALSE;
+    GVL.astAxes[x].stConfig.stAirpadBrake.bExternalBrakeConnected := FALSE; //External brake meaning we need to control the brake with an ouput and is not controlled through the driver.
+    GVL.astAxes[x].stConfig.stAirpadBrake.bExternalBrakeFeedbackConnected := FALSE; //TRUE if there is a dedicated external signal for the brake status.
     GVL.astAxes[x].stConfig.stAirpadBrake.bAirpadConnected := FALSE;
-    GVL.astAxes[x].stConfig.stAirpadBrake.bAirpadFeedbackConnected := FALSE;
+    GVL.astAxes[x].stConfig.stAirpadBrake.bAirpadFeedbackConnected := FALSE; //TRUE if there is a dedicated external signal for the airpad status.
 
     //Add the variables of Advanced homing parameters if you need to chage them
     GVL.astAxes[x].stConfig.stHomingConfig.bDisableDriveAccess := TRUE;
-    GVL.astAxes[x].stConfig.stHomingConfig.eLimitSwitchMode := MC_Switch_Mode.mcRisingEdge;
+    GVL.astAxes[x].stConfig.stHomingConfig.eLimitSwitchMode := MC_Switch_Mode.mcRisingEdge; //Rising edge: stays on limit switch/Falling edge: bounces off limit switch.
     GVL.astAxes[x].stConfig.stHomingConfig.eRefSwitchMode := MC_Switch_Mode.mcRisingEdge;
 END_IF
 *)

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -3,7 +3,7 @@
   <POU Name="MAIN" Id="{33eb6f49-7781-4211-a70b-87ada6d80cb7}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM MAIN
 VAR
-    sVersion: STRING := '2.9.0'; //Version for tc_generic_structure
+    sVersion: STRING := '2.9.1'; //Version for tc_generic_structure
     aIAxes: ARRAY [1..GVL_APP.nAXIS_NUM] OF I_Axis; //Array of axis interfaces, size determined by the total number of axes in the system
     afbAxes: ARRAY [1..GVL_APP.nAXIS_NUM] OF FB_Axis; //Array of axis function blocks, one for each axis
     afbPneumaticAxes: ARRAY [1..GVL_APP.nPNEUMATIC_AXIS_NUM] OF FB_PneumaticAxis; //Array of pneumatic axis function blocks, size determined by the number of pneumatic axes


### PR DESCRIPTION
The configurable ENUMs in GVL_APP and Axis_template were changed from the simple integer number to the explicit variable name for a better understanding.

The relase notes and the sVersion variabel in MAIN were also chagned to reflect the v2.9.1