### PR TITLE
MBP-247: Position Recovery Improvements 

### DIFF
--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -228,16 +228,16 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             //First cycle of the PLC, do nothing just give one cycle for variables to initialise
             IF NOT bPositionRestoreDone THEN
                 eStartUp := eReadAxisFeedbackType;
-                nRetry := 0;
             END_IF
 
         eReadAxisFeedbackType:
-            IF NOT GVL.astAxesPersistent[iCurrentAxis].bInitializedAtShutdown THEN
+            IF NOT GVL.astAxesPersistent[iCurrentAxis].bInitializedAtShutdown OR nRetry > 5 THEN
                 eStartUp := eNextAxis;
+                GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := FALSE;
+                nRetry := 0;
                 RETURN;
             END_IF
-            //Execute the function blocks to read the encoder reference system (0=inc OR 1=ABS)
-            afbReadEncRefSys[iCurrentAxis].Enable := TRUE;
+            fbReadEncRefSys.Enable := TRUE;
             eStartUp := eCheckReadDone;
 
         eCheckReadDone:
@@ -251,7 +251,6 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                     nRetry := nRetry + 1;
                     fbReadEncRefSys.Enable := FALSE;
                     eStartUp := eReadAxisFeedbackType;
-                    nRetry := nRetry + 1; //Counter used for troubleshooting to see how many cycles it takes before afbReadEncRefSys function blocks are read correctly
                     RETURN;
                 END_IF
             END_IF

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -321,7 +321,7 @@ END_IF
     <Action Name="STORE_PERSISTENT" Id="{cb5c9254-2e5f-47b1-9baa-10e728a961b0}" FolderPath="POSITION_RECOVERY\">
       <Implementation>
         <ST><![CDATA[FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-    //Store Position beofre shutdown
+    //Store Position at shutdown
     astAxesPersistent[iAxes].fPositionAtShutdown := GVL.astAxes[iAxes].Axis.NcToPlc.ActPos;
 
     //Store encoder position BIAS at shutdown
@@ -334,6 +334,17 @@ END_IF
         astAxesPersistent[iAxes].bMovingAtShutdown := TRUE;
     END_IF
 END_FOR
+
+//Store date and time at shutdown
+GVL.timeAtShutdownPersistent := timeAsDT;
+]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="SYSTEM_TIME" Id="{ed24f670-0ba1-0f6e-340a-0db7ff2026cb}">
+      <Implementation>
+        <ST><![CDATA[fbSystemTime(timeLoDW => timeAsFileTime.dwLowDateTime, timeHiDW => timeAsFileTime.dwHighDateTime);
+timeAsDT := FILETIME_TO_DT(timeAsFileTime); 
+
 ]]></ST>
       </Implementation>
     </Action>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -167,8 +167,17 @@ Pneumatic_Box();
 
 
 IF bRestoreOnStartup AND eGlobalSUpsState = eSUPS_PowerOK THEN
-    bRestoreOnStartup := FALSE;
-    bRestoreExecute := TRUE;
+	bRestoreOnStartup := FALSE;
+	bRestoreExecute := TRUE;
+	SYSTEM_TIME();
+	timeAsDTAtStartup := timeAsDT;
+
+	FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
+		IF NOT astAxes[iAxes].stStatus.bAxisInitialized THEN
+			//Do nothing if axis has not been initialized
+			RETURN;
+		END_IF
+	END_FOR
 END_IF
 
 //Upon startup bPositionRestoreDone will be set to FALSE, after successfully completing the following code it will be set TRUE

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -19,7 +19,8 @@ VAR
 
     bPositionRestoreDone: BOOL := FALSE;
     bRestoreExecute: BOOL := FALSE;
-    nRetry: INT := 0; //Counts number of retries to read encoder reference
+    nReadEncRefSysRetry: UINT := 0; //Counts number of retries to read encoder reference system
+    nCheckRestoreRetry: UINT := 0; //Counts number of retries to restore axis position or position bias
     iAxes: UINT; //Index for, for-loops in position recovery actions
     iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
 
@@ -230,43 +231,50 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             END_IF
 
         eReadAxisFeedbackType:
-            IF NOT GVL.astAxesPersistent[iCurrentAxis].bInitializedAtShutdown OR nRetry > 5 THEN
-                eStartUp := eNextAxis;
+            IF NOT GVL.astAxesPersistent[iCurrentAxis].bInitializedAtShutdown OR nReadEncRefSysRetry > 5 THEN
                 GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := FALSE;
-                nRetry := 0;
+                eRestorePositions := eNextAxis;
                 RETURN;
             END_IF
             fbReadEncRefSys.Enable := TRUE;
-            eStartUp := eCheckReadDone;
+            eRestorePositions := eCheckReadDone;
 
         eCheckReadDone:
-            //Check that the encoder reference system has been read for the current axis -> if busy then continue with PLC cycle and check again next time.
-            IF NOT fbReadEncRefSys.Valid THEN
+            // Check whether the encoder reference system has been read for the current axis.
+            // If the FB is busy, continue with the PLC cycle and check again on the next cycle.
+            IF NOT fbReadEncRefSys.Valid OR fbReadEncRefSys.Error THEN
                 IF fbReadEncRefSys.Busy THEN
                     RETURN;
                 ELSE
-                    //.Valid=FALSE and .Busy=FALSE which indicateds the FB probably hasn't started and thus needs to see a rising edge.
+                    //.Valid=FALSE, .Busy=FALSE and .Error=TRUE which indicates the FB probably hasn't started or in error state and thus needs to see a rising edge.
                     //Set .Enable=FALSE and go back a step in the CASE statement.
-                    nRetry := nRetry + 1;
+                    nReadEncRefSysRetry := nReadEncRefSysRetry + 1;
                     fbReadEncRefSys.Enable := FALSE;
-                    eStartUp := eReadAxisFeedbackType;
+                    eRestorePositions := eReadAxisFeedbackType;
                     RETURN;
                 END_IF
             END_IF
 
-            eStartUp := eExecuteRestore;
+            eRestorePositions := eExecuteRestore;
 
         eExecuteRestore:
-            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-                CASE LREAL_TO_INT(fbReadEncRefSys.Value) OF
+            IF nCheckRestoreRetry > 5 THEN
+                GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := FALSE;
+                eRestorePositions := eNextAxis;
+                RETURN;
+            END_IF
 
-                    E_EncoderRefSys.INCREMENTAL, E_EncoderRefSys.ABSOLUTE_MODULO, E_EncoderRefSys.INCREMENTAL_SINGLETURN_ABSOLUTE:
-                        //Restore position value for incremental encoders
-                        IF GVL.astAxesPersistent[iCurrentAxis].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-                            fbSetHomePosition.Execute := TRUE;
-                        ELSE
-                            fbSetPosition.Execute := TRUE;
-                        END_IF
+            CASE LREAL_TO_INT(fbReadEncRefSys.Value) OF
+
+                E_EncoderRefSys.INCREMENTAL, E_EncoderRefSys.ABSOLUTE_MODULO, E_EncoderRefSys.INCREMENTAL_SINGLETURN_ABSOLUTE:
+                    //Restore position value for incremental encoders
+                    IF GVL.astAxesPersistent[iCurrentAxis].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                        fbSetHomePosition.Execute := TRUE;
+                        eRestorePositions := eCheckRestoreIncrementalSetHomePos;
+                    ELSE
+                        fbSetPosition.Execute := TRUE;
+                        eRestorePositions := eCheckRestoreIncrementalSetPos;
+                    END_IF
 
 
                 E_EncoderRefSys.ABSOLUTE, E_EncoderRefSys.ABSOLUTE_MULTITURN_RANGE, E_EncoderRefSys.ABSOLUTE_SINGLETURN_RANGE:
@@ -328,9 +336,9 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             fbSetPosition.Execute := FALSE;
             fbWritePositionBias.Execute := FALSE;
             fbReadEncRefSys.Enable := FALSE;
-            eStartUp := eNextAxis;
+            nReadEncRefSysRetry := 0;
+            nCheckRestoreRetry := 0;
 
-        eNextAxis:
             iCurrentAxis := iCurrentAxis + 1;
             IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
                 eStartUp := eRestoreFinished;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -15,7 +15,7 @@ VAR
     fbCX5130UPS: FB_S_UPS_CX51x0;
     fbC6017UPS: FB_S_UPS_BAPI;
     eSelUpsMode: E_S_UPS_Mode := eSUPS_WrPersistData_Shutdown; //Selected UPS mode
-    eStartUp: (eColdStart, eReadAxisFeedbackType, eCheckReadDone, eExecuteRestore, eCheckRestore, eNextAxis, eRestoreFinished);
+    eRestorePositions: (eColdStart, eReadAxisFeedbackType, eCheckReadDone, eExecuteRestore, eCheckRestoreAbsolute, eCheckRestoreIncrementalSetPos, eCheckRestoreIncrementalSetHomePos, eNextAxis, eRestoreFinished);
 
     bPositionRestoreDone: BOOL := FALSE;
     bRestoreExecute: BOOL := FALSE;
@@ -222,12 +222,11 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
     END_IF
 
-
-    CASE eStartUp OF
+    CASE eRestorePositions OF
         eColdStart:
             //First cycle of the PLC, do nothing just give one cycle for variables to initialise
             IF NOT bPositionRestoreDone THEN
-                eStartUp := eReadAxisFeedbackType;
+                eRestorePositions := eReadAxisFeedbackType;
             END_IF
 
         eReadAxisFeedbackType:
@@ -269,55 +268,62 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                             fbSetPosition.Execute := TRUE;
                         END_IF
 
-                    E_EncoderRefSys.ABSOLUTE, E_EncoderRefSys.ABSOLUTE_MULTITURN_RANGE, E_EncoderRefSys.ABSOLUTE_SINGLETURN_RANGE:
-                        //Restore encoder position BIAS for absolute encoders
-                        fbWritePositionBias.Execute := TRUE;
-                END_CASE
+
+                E_EncoderRefSys.ABSOLUTE, E_EncoderRefSys.ABSOLUTE_MULTITURN_RANGE, E_EncoderRefSys.ABSOLUTE_SINGLETURN_RANGE:
+                    //Restore encoder position bias for absolute encoders
+                    fbWritePositionBias.Execute := TRUE;
+                    eRestorePositions := eCheckRestoreAbsolute;
+
+            END_CASE
+
+        eCheckRestoreAbsolute:
+
+            IF fbWritePositionBias.Busy THEN
+                RETURN;
             END_IF
 
-            eStartUp := eCheckRestore;
-
-        eCheckRestore:
-            //Check that the set position and write encoder bias fbs are finished
-            //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
-            //bPositionRestoreDone will never get set to TRUE and will take up cycle time
-            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-                    CASE LREAL_TO_INT(fbReadEncRefSys.Value) OF
-
-                        E_EncoderRefSys.INCREMENTAL, E_EncoderRefSys.ABSOLUTE_MODULO, E_EncoderRefSys.INCREMENTAL_SINGLETURN_ABSOLUTE:
-                            IF fbSetPosition.Busy THEN
-                                RETURN;
-                            END_IF
-
-                            IF fbSetHomePosition.Busy THEN
-                                RETURN;
-                            END_IF
-
-                            IF GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-                                IF NOT fbSetPosition.Done THEN
-                                    fbSetPosition.Execute := FALSE;
-                                    eStartUp := eExecuteRestore;
-                                    RETURN;
-                                END_IF
-                            END_IF
-
-                            IF GVL.astAxesPersistent[iCurrentAxis].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-                                IF NOT fbSetHomePosition.Done THEN
-                                    fbSetHomePosition.Execute := FALSE;
-                                    eStartUp := eExecuteRestore;
-                                    RETURN;
-                                END_IF
-                            END_IF
-
-                        E_EncoderRefSys.ABSOLUTE, E_EncoderRefSys.ABSOLUTE_MULTITURN_RANGE, E_EncoderRefSys.ABSOLUTE_SINGLETURN_RANGE:
-                            IF NOT fbWritePositionBias.Done THEN
-                                fbWritePositionBias.Execute := FALSE;
-                                eStartUp := eExecuteRestore;
-                                RETURN;
-                            END_IF
-                    END_CASE
+            IF NOT fbWritePositionBias.Done OR fbWritePositionBias.Error THEN
+                fbWritePositionBias.Execute := FALSE;
+                nCheckRestoreRetry := nCheckRestoreRetry + 1;
+                eRestorePositions := eExecuteRestore;
+                RETURN;
             END_IF
 
+            GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := TRUE;
+            eRestorePositions := eNextAxis;
+
+        eCheckRestoreIncrementalSetPos:
+            IF fbSetPosition.Busy THEN
+                RETURN;
+            END_IF
+
+            IF NOT fbSetPosition.Done OR fbSetPosition.Error THEN
+                fbSetPosition.Execute := FALSE;
+                nCheckRestoreRetry := nCheckRestoreRetry + 1;
+                eRestorePositions := eExecuteRestore;
+                RETURN;
+            END_IF
+
+            GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := TRUE;
+            eRestorePositions := eNextAxis;
+
+        eCheckRestoreIncrementalSetHomePos:
+            IF fbSetHomePosition.Busy THEN
+                RETURN;
+            END_IF
+
+            IF NOT fbSetHomePosition.Done OR fbSetHomePosition.Error THEN
+                fbSetHomePosition.Execute := FALSE;
+                nCheckRestoreRetry := nCheckRestoreRetry + 1;
+                eRestorePositions := eExecuteRestore;
+                RETURN;
+            END_IF
+
+            GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := TRUE;
+            eRestorePositions := eNextAxis;
+
+        eNextAxis:
+            //Reset FBs and retry counter before reading the next axis.
             fbSetHomePosition.Execute := FALSE;
             fbSetPosition.Execute := FALSE;
             fbWritePositionBias.Execute := FALSE;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -21,14 +21,14 @@ VAR
     nRetry: INT; //A counter for startup actions
     iAxes: UINT; //index for for loops in Position recovery actions
     afbReadEncRefSys: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
-    afbSetPosition: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_SetPosition;
+    afbSetHomePosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_Home;
+    stHomingParameter: MC_HomingParameter;
     afbReadPositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbWritePositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_WriteParameter;
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
     timeAsDTAtStartup: DT;
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 END_VAR
-
 VAR PERSISTENT
     bRestoreOnStartup: BOOL; //Determines whether the axis positions should be restored automatically during system startup
 END_VAR
@@ -188,14 +188,15 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
     //Cycle through set position and MC_WritePArameter function blocks for each axis
     FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-        afbSetPosition[iAxes](
+        afbSetHomePosition[iAxes](
             Axis := GVL.astAxes[iAxes].Axis,
-            Position := astAxesPersistent[iAxes].fPositionAtShutdown);
+            Position := astAxesPersistent[iAxes].fPositionAtShutdown,
+            HomingMode := MC_HomingMode.MC_Direct);
 
         afbWritePositionBias[iAxes](
-            Axis:= GVL.astAxes[iAxes].Axis,
-            ParameterNumber:= E_AxisParameters.AxisEncoderOffset,
-            Value:= astAxesPersistent[iAxes].fEncoderBiasAtShutdown);
+            Axis := GVL.astAxes[iAxes].Axis,
+            ParameterNumber := E_AxisParameters.AxisEncoderOffset,
+            Value := astAxesPersistent[iAxes].fEncoderBiasAtShutdown);
     END_FOR
 
     CASE eStartUp OF
@@ -246,7 +247,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                     (afbReadEncRefSys[iAxes].Value = 0 OR
                      afbReadEncRefSys[iAxes].Value = 2 OR
                      afbReadEncRefSys[iAxes].Value = 4) THEN
-                       afbSetPosition[iAxes].Execute := TRUE;
+                       afbSetHomePosition[iAxes].Execute := TRUE;
                     //Restore encoder position BIAS for absolute encoders
                     ELSIF afbReadEncRefSys[iAxes].Value = 1 OR
                     afbReadEncRefSys[iAxes].Value = 3 OR
@@ -259,7 +260,6 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             END_FOR
             eStartUp := eCheckRestore;
 
-
         eCheckRestore:
             //Check the set position and write enocder BIAS fbs are finished
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
@@ -271,16 +271,15 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                     (afbReadEncRefSys[iAxes].Value = 0 OR
                      afbReadEncRefSys[iAxes].Value = 2 OR
                      afbReadEncRefSys[iAxes].Value = 4) THEN
-                         IF afbSetPosition[iAxes].Busy THEN
+                        IF afbSetHomePosition[iAxes].Busy THEN
                              //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
                              RETURN;
-                         END_IF
-                            IF NOT afbSetPosition[iAxes].Done THEN
-                                afbSetPosition[iAxes].Execute := FALSE;
+                        ELSIF NOT afbSetHomePosition[iAxes].Done THEN
+                                afbSetHomePosition[iAxes].Execute := FALSE;
                                 eStartUp := eExecuteRestore;
                                 RETURN;
-                            END_IF
-                     ELSIF afbReadEncRefSys[iAxes].Value = 1 OR
+                        END_IF
+                    ELSIF afbReadEncRefSys[iAxes].Value = 1 OR
                      afbReadEncRefSys[iAxes].Value = 3 OR
                      afbReadEncRefSys[iAxes].Value = 5 THEN
                         IF NOT afbWritePositionBias[iAxes].Done THEN
@@ -298,15 +297,10 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
         eFinishRestore:
             //Remove execute = TRUE for afbRestorePosition and fbWritePositionBias
             FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                afbSetPosition[iAxes].Execute := FALSE;
+                afbSetHomePosition[iAxes].Execute := FALSE;
                 afbWritePositionBias[iAxes].Execute := FALSE;
                 bPositionRestoreDone := TRUE;
                 bRestoreExecute := FALSE;
-                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-                    GVL.astAxes[iAxes].stControl.bEnable := TRUE;
-                    GVL.astAxes[iAxes].stControl.eCommand := E_MotionFunctions.eHome;
-                    GVL.astAxes[iAxes].stControl.bExecute := TRUE;
-                END_IF
             END_FOR
     END_CASE
 END_IF

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -155,7 +155,7 @@ Pneumatic_Box();
 //There is a enum to allow for different types of restore modes, currently only one is implemented.
 //0 'DontRestore'
 //1 'RestoreWithoutHome' - Restores the position using a set position fb and does not set the home bit in the axis struct.
-//2 ''RestoreWithHome' - Restores the position using a set position fb and does set the home bit in the axis struct.
+//2 'RestoreWithHome' - Restores the position using a set position fb and does set the home bit in the axis struct.
 //Note from Beckhoff: "A maximum of 1 MB persistent data can be reliably saved over the entire service life."
 //Encoder Reference system types: https://infosys.beckhoff.com/english.php?content=../content/1033/tf50x0_tc3_nc_ptp/3439907723.html&id=
 //INCREMENTAL=0;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -38,14 +38,6 @@ VAR
     tReadPosition: TIME := T#5S; //Interval time
     fPositionDifferenceLimit: LREAL := 0.001; //The acceptable difference between the sampled position and position at shutdown
 END_VAR
-VAR CONSTANT
-    INCREMENTAL: UINT := 0;
-    ABSOLUTE: UINT := 1;
-    ABSOLUTE_MODULO: UINT := 2;
-    ABSOLUTE_MULTITURN_RANGE: UINT := 3; //(with single overflow)
-    INCREMENTAL_SINGLETURN_ABSOLUTE: UINT := 4;
-    ABSOLUTE_SINGLETURN_RANGE: UINT :=5; //(with single overflow)
-END_VAR
 VAR PERSISTENT
     bRestoreOnStartup: BOOL; //Determines whether the axis positions should be restored automatically during system startup
 END_VAR
@@ -282,18 +274,20 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
         eExecuteRestore:
             //Execute position and encoder BIAS restore by setting Execute = TRUE
             IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-                    CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
-                        INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
-                            //Restore position value for incremental encoders
-                            IF GVL.astAxesPersistent[iAxes].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iAxes].bMovingAtShutdown THEN
-                                afbSetHomePosition[iCurrentAxis].Execute := TRUE;
-                            ELSE
-                                afbSetPosition[iCurrentAxis].Execute := TRUE;
-                            END_IF
-                        ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
-                            //Restore encoder position BIAS for absolute encoders
-                            afbWritePositionBias[iCurrentAxis].Execute := TRUE;
-                    END_CASE
+                CASE LREAL_TO_INT(fbReadEncRefSys.Value) OF
+
+                    E_EncoderRefSys.INCREMENTAL, E_EncoderRefSys.ABSOLUTE_MODULO, E_EncoderRefSys.INCREMENTAL_SINGLETURN_ABSOLUTE:
+                        //Restore position value for incremental encoders
+                        IF GVL.astAxesPersistent[iCurrentAxis].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                            fbSetHomePosition.Execute := TRUE;
+                        ELSE
+                            fbSetPosition.Execute := TRUE;
+                        END_IF
+
+                    E_EncoderRefSys.ABSOLUTE, E_EncoderRefSys.ABSOLUTE_MULTITURN_RANGE, E_EncoderRefSys.ABSOLUTE_SINGLETURN_RANGE:
+                        //Restore encoder position BIAS for absolute encoders
+                        fbWritePositionBias.Execute := TRUE;
+                END_CASE
             END_IF
 
             eStartUp := eCheckRestore;
@@ -303,15 +297,14 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
             //bPositionRestoreDone will never get set to TRUE and will take up cycle time
             IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-                    CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
-                        INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
-                            IF afbSetPosition[iCurrentAxis].Busy THEN
-                                //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+                    CASE LREAL_TO_INT(fbReadEncRefSys.Value) OF
+
+                        E_EncoderRefSys.INCREMENTAL, E_EncoderRefSys.ABSOLUTE_MODULO, E_EncoderRefSys.INCREMENTAL_SINGLETURN_ABSOLUTE:
+                            IF fbSetPosition.Busy THEN
                                 RETURN;
                             END_IF
 
-                            IF afbSetHomePosition[iCurrentAxis].Busy THEN
-                                //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+                            IF fbSetHomePosition.Busy THEN
                                 RETURN;
                             END_IF
 
@@ -331,9 +324,9 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                                 END_IF
                             END_IF
 
-                        ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
-                            IF NOT afbWritePositionBias[iCurrentAxis].Done THEN
-                                afbWritePositionBias[iCurrentAxis].Execute := FALSE;
+                        E_EncoderRefSys.ABSOLUTE, E_EncoderRefSys.ABSOLUTE_MULTITURN_RANGE, E_EncoderRefSys.ABSOLUTE_SINGLETURN_RANGE:
+                            IF NOT fbWritePositionBias.Done THEN
+                                fbWritePositionBias.Execute := FALSE;
                                 eStartUp := eExecuteRestore;
                                 RETURN;
                             END_IF

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -78,11 +78,11 @@ END_FOR
         <ST><![CDATA[CASE GVL_APP.eCPUType OF
     E_CPUType.CX5130:
       //Handle UPS configuration for CX5130 CPU type
-        fbCX5130UPS(eUpsMode := eUpsMode);
+        fbCX5130UPS(eUpsMode := eSelUpsMode);
 
     E_CPUType.C6017_0020:
      //Handle UPS configuration for C6017-0020 CPU type
-        fbC6017UPS(eUPSMode := eUPSMode);
+        fbC6017UPS(eUPSMode := eSelUpsMode);
 END_CASE
 
 FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
@@ -99,6 +99,7 @@ IF eGlobalSUpsState = eSUPS_PowerFailure THEN
     //First cycle of powerfailure
     //Execute code that should only be done once with each powerfailure, i.e. increase powerfailure counter
     bRestoreOnStartup := TRUE;
+	SYSTEM_TIME();
     STORE_PERSISTENT();
     RETURN;
 ELSIF eGlobalSUpsState <> eSUPS_PowerOK THEN

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -365,8 +365,20 @@ END_IF
     //Store encoder position BIAS at shutdown
     astAxesPersistent[iAxes].fEncoderBiasAtShutdown := afbReadPositionBias[iAxes].Value;
 
-    //Store homing status at shutdown
+    //Store axis status at shutdown
+    astAxesPersistent[iAxes].bInitialized := GVL.astAxes[iAxes].stStatus.bAxisInitialized;
     astAxesPersistent[iAxes].bHomedAtShutdown := GVL.astAxes[iAxes].stStatus.bHomed;
+    astAxesPersistent[iAxes].stMotionState := GVL.astAxes[iAxes].Axis.Status.MotionState;
+    astAxesPersistent[iAxes].bError := GVL.astAxes[iAxes].Axis.Status.Error;
+    astAxesPersistent[iAxes].nErrorID := GVL.astAxes[iAxes].Axis.Status.ErrorID;
+    astAxesPersistent[iAxes].bErrorStop := GVL.astAxes[iAxes].Axis.Status.ErrorStop;
+    astAxesPersistent[iAxes].bStandStill := GVL.astAxes[iAxes].Axis.Status.StandStill;
+    astAxesPersistent[iAxes].bHasBeenStopped := GVL.astAxes[iAxes].Axis.Status.HasBeenStopped;
+    astAxesPersistent[iAxes].bDisabled := GVL.astAxes[iAxes].Axis.Status.Disabled;
+    astAxesPersistent[iAxes].bMoving := GVL.astAxes[iAxes].Axis.Status.Moving;
+
+    astAxesPersistent[iAxes].nCycles := astAxesPersistent[iAxes].nCycles + 1;
+    astAxesPersistent[iAxes].fPositionDifference := ABS(afCurrentPosition[iAxes] - astAxesPersistent[iAxes].fPositionAtShutdown);
 
     //Store value of moving at shutdown
     IF GVL.astAxes[iAxes].Axis.Status.Disabled OR astAxesPersistent[iAxes].fPositionDifference < fPositionDifferenceLimit THEN

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -217,21 +217,26 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                 ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
                 ReadMode := E_READMODE.READMODE_ONCE);
 
-            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR NOT GVL.astAxesPersistent[iAxes].bHomedAtShutdown THEN
-                afbSetPosition[iAxes](
-                    Axis := GVL.astAxes[iAxes].Axis,
-                    Position := astAxesPersistent[iAxes].fPositionAtShutdown);
-            ELSIF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-                afbSetHomePosition[iAxes](
-                    Axis := GVL.astAxes[iAxes].Axis,
-                    Position := astAxesPersistent[iAxes].fPositionAtShutdown,
-                    HomingMode := MC_HomingMode.MC_Direct);
+            //Position recovery for incremental encoders
+            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestorePosition THEN
+                IF GVL.astAxesPersistent[iAxes].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iAxes].bMovingAtShutdown THEN
+                    afbSetHomePosition[iAxes](
+                        Axis := GVL.astAxes[iAxes].Axis,
+                        Position := astAxesPersistent[iAxes].fPositionAtShutdown,
+                        HomingMode := MC_HomingMode.MC_Direct);
+                ELSE
+                    afbSetPosition[iAxes](
+                        Axis := GVL.astAxes[iAxes].Axis,
+                        Position := astAxesPersistent[iAxes].fPositionAtShutdown);
+                END_IF
             END_IF
-
+            //Position recovery for absolute encoders
+            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestorePositionBias THEN
             afbWritePositionBias[iAxes](
                 Axis := GVL.astAxes[iAxes].Axis,
                 ParameterNumber := E_AxisParameters.AxisEncoderOffset,
                 Value := astAxesPersistent[iAxes].fEncoderBiasAtShutdown);
+            END_IF
         END_FOR
 
 
@@ -244,7 +249,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             END_IF
 
         eReadAxisFeedbackType:
-            IF NOT GVL.astAxesPersistent[iCurrentAxis].bInitialized THEN
+            IF NOT GVL.astAxesPersistent[iCurrentAxis].bInitializedAtShutdown THEN
                 eStartUp := eNextAxis;
                 RETURN;
             END_IF
@@ -279,14 +284,14 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
                     CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
                         INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
-                            // Restore position value for incremental encoders
-                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-                                afbSetPosition[iCurrentAxis].Execute := TRUE;
-                            ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                            //Restore position value for incremental encoders
+                            IF GVL.astAxesPersistent[iAxes].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iAxes].bMovingAtShutdown THEN
                                 afbSetHomePosition[iCurrentAxis].Execute := TRUE;
+                            ELSE
+                                afbSetPosition[iCurrentAxis].Execute := TRUE;
                             END_IF
                         ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
-                            // Restore encoder position BIAS for absolute encoders
+                            //Restore encoder position BIAS for absolute encoders
                             afbWritePositionBias[iCurrentAxis].Execute := TRUE;
                     END_CASE
             END_IF
@@ -310,7 +315,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                                 RETURN;
                             END_IF
 
-                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                            IF GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
                                 IF NOT afbSetPosition[iCurrentAxis].Done THEN
                                     afbSetPosition[iCurrentAxis].Execute := FALSE;
                                     eStartUp := eExecuteRestore;
@@ -318,7 +323,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                                 END_IF
                             END_IF
 
-                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                            IF GVL.astAxesPersistent[iAxes].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iAxes].bMovingAtShutdown THEN
                                 IF NOT afbSetHomePosition[iCurrentAxis].Done THEN
                                     afbSetHomePosition[iCurrentAxis].Execute := FALSE;
                                     eStartUp := eExecuteRestore;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -172,11 +172,10 @@ Pneumatic_Box();
     <Action Name="RESTORE_POSITIONS" Id="{0c7ee537-7bd9-4833-b428-c17cbb57e893}" FolderPath="POSITION_RECOVERY\">
       <Implementation>
         <ST><![CDATA[(*
-This ACT will restore the position of an incremental axis and the position bias of an absolute axis on startup,
-with the actual position and position bias being read before losing power. It checks the type of axis, 0=incremental,
-and that the axis was stationary at shut down. Because 0 equates to incremental we also need to check that the data is valid,
-otherwise by default it would restore all axes. A restore will only be performed on a loss of power,
-this code shouldn't make any changes on a reset cold, a rest origin or a download.
+This ACT will restore the position of an incremental axis and the position bias of an absolute axis on startup after a power failure,
+with the actual position and position bias being read before losing power. It checks the type of axis
+and that the axis was stationary at shutdown. A restore will only be performed on a loss of power.
+This code shouldn't make any changes on a cold reset, a reset origin, or a download.
 Note from Beckhoff: "A maximum of 1 MB persistent data can be reliably saved over the entire service life."
 *)
 
@@ -193,35 +192,35 @@ IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
 END_IF
 
 
-//Upon startup bPositionRestoreDone will be set to FALSE, after successfully completing the following code it will be set TRUE
-//and should stay TRUE for the rest of the time the PLC is operational, thus this routine should only be completed once.
+//Upon startup, bPositionRestoreDone will be set to FALSE. After successfully completing the following code, it will be set to TRUE
+//and should remain TRUE for the rest of the time the PLC is operational. Thus, this routine should only be completed once.
 IF bRestoreExecute AND NOT bPositionRestoreDone THEN
+
+    IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eDontRestore THEN
+        GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := FALSE;
+        eRestorePositions := eNextAxis;
+    END_IF
 
     fbReadEncRefSys(
         Axis := GVL.astAxes[iCurrentAxis].Axis,
         ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
         ReadMode := E_READMODE.READMODE_ONCE);
+
     //Position recovery for incremental encoders
-    IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestorePosition THEN
-        IF GVL.astAxesPersistent[iCurrentAxis].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-            fbSetHomePosition(
-                Axis := GVL.astAxes[iCurrentAxis].Axis,
-                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown,
-                HomingMode := MC_HomingMode.MC_Direct);
-        ELSE
-            fbSetPosition(
-                Axis := GVL.astAxes[iCurrentAxis].Axis,
-                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown);
-        END_IF
-    END_IF
+    fbSetHomePosition(
+        Axis := GVL.astAxes[iCurrentAxis].Axis,
+        Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown,
+        HomingMode := MC_HomingMode.MC_Direct);
+
+    fbSetPosition(
+        Axis := GVL.astAxes[iCurrentAxis].Axis,
+        Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown);
 
     //Position recovery for absolute encoders
-    IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestorePositionBias THEN
-        fbWritePositionBias(
-            Axis := GVL.astAxes[iCurrentAxis].Axis,
-            ParameterNumber := E_AxisParameters.AxisEncoderOffset,
-            Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
-    END_IF
+    fbWritePositionBias(
+        Axis := GVL.astAxes[iCurrentAxis].Axis,
+        ParameterNumber := E_AxisParameters.AxisEncoderOffset,
+        Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
 
     CASE eRestorePositions OF
         eColdStart:
@@ -341,11 +340,11 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
             iCurrentAxis := iCurrentAxis + 1;
             IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
-                eStartUp := eRestoreFinished;
+                eRestorePositions := eRestoreFinished;
                 bPositionRestoreDone := TRUE;
                 bRestoreExecute := FALSE;
             ELSE
-                eStartUp := eReadAxisFeedbackType;
+                eRestorePositions := eReadAxisFeedbackType;
             END_IF
 
         eRestoreFinished:

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -276,11 +276,15 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                     (afbReadEncRefSys[iAxes].Value = 0 OR
                      afbReadEncRefSys[iAxes].Value = 2 OR
                      afbReadEncRefSys[iAxes].Value = 4) THEN
-                        IF NOT afbSetPosition[iAxes].Done THEN
-                            afbSetPosition[iAxes].Execute := FALSE;
-                            eStartUp := eExecuteRestore;
-                            RETURN;
-                        END_IF
+						 IF afbSetPosition[iAxes].Busy THEN
+							 //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+							 RETURN;
+						 END_IF
+							IF NOT afbSetPosition[iAxes].Done THEN
+								afbSetPosition[iAxes].Execute := FALSE;
+								eStartUp := eExecuteRestore;
+								RETURN;
+							END_IF
                      ELSIF afbReadEncRefSys[iAxes].Value = 1 OR
                      afbReadEncRefSys[iAxes].Value = 3 OR
                      afbReadEncRefSys[iAxes].Value = 5 THEN

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -10,7 +10,7 @@ VAR
     hmiAxisSelection: INT := 1; //Specifies the currently selected axis for HMI operations, allowing the user to control a specific axis
     hmiPneumaticAxisSelection: INT := 1; //Specifies the currently selected pneumatic axis for HMI operation, allowing the user to control the specific axis
 
-	//Startup, Shutdown and UPS
+    //Startup, Shutdown and UPS
     fbCX5130UPS: FB_S_UPS_CX51x0;
     fbC6017UPS: FB_S_UPS_BAPI;
     eSelUpsMode: E_S_UPS_Mode := eSUPS_WrPersistData_Shutdown; //Selected UPS mode
@@ -20,10 +20,10 @@ VAR
     bExecuteReadEncRefSys: BOOL := FALSE;
     nRetry: INT; //Counter for startup actions
     iAxes: UINT := 1; //Index for, for loops in position recovery actions
-	iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
+    iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
     afbReadEncRefSys: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbSetHomePosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_Home;
-	afbSetPosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_SetPosition;
+    afbSetPosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_SetPosition;
     afbReadPositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbWritePositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_WriteParameter;
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
@@ -31,12 +31,12 @@ VAR
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 END_VAR
 VAR CONSTANT
-	INCREMENTAL: UINT := 0;
-	ABSOLUTE: UINT := 1;
-	ABSOLUTE_MODULO: UINT := 2;
-	ABSOLUTE_MULTITURN_RANGE: UINT := 3; //(with single overflow)
-	INCREMENTAL_SINGLETURN_ABSOLUTE: UINT := 4;
-	ABSOLUTE_SINGLETURN_RANGE: UINT :=5; //(with single overflow)
+    INCREMENTAL: UINT := 0;
+    ABSOLUTE: UINT := 1;
+    ABSOLUTE_MODULO: UINT := 2;
+    ABSOLUTE_MULTITURN_RANGE: UINT := 3; //(with single overflow)
+    INCREMENTAL_SINGLETURN_ABSOLUTE: UINT := 4;
+    ABSOLUTE_SINGLETURN_RANGE: UINT :=5; //(with single overflow)
 END_VAR
 VAR PERSISTENT
     bRestoreOnStartup: BOOL; //Determines whether the axis positions should be restored automatically during system startup
@@ -46,6 +46,10 @@ END_VAR
       <ST><![CDATA[POSITION_RECOVERY();
 PROG();
 AXES();
+
+
+
+
 ]]></ST>
     </Implementation>
     <Folder Name="POSITION_RECOVERY" Id="{3561f6ef-e145-4ed3-9839-f17334bd2d97}" />
@@ -173,44 +177,44 @@ IF bRestoreOnStartup AND eGlobalSUpsState = eSUPS_PowerOK THEN
     bRestoreOnStartup := FALSE;
     bRestoreExecute := TRUE;
     timeAsDTAtStartup := FILETIME64_TO_DT(F_GetSystemTime());
-	iCurrentAxis := 1;
+    iCurrentAxis := 1;
 END_IF
 
-IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN 
-	RETURN; 
+IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
+    RETURN;
 END_IF
 
 //Upon startup bPositionRestoreDone will be set to FALSE, after successfully completing the following code it will be set TRUE
 //and should stay TRUE for the rest of the time the PLC is operational, thus this routine should only be completed once.
 IF bRestoreExecute AND NOT bPositionRestoreDone THEN
-   
-	IF NOT astAxes[iCurrentAxis].stStatus.bAxisInitialized OR NOT astAxesPersistent[iCurrentAxis].bHomedAtShutdown THEN
-		//If current axis has not been initialized or was not homed before power failure, perform position recovery for next axis
-		eStartUp := eNextAxis;
-	ELSE
-		//Cycle through function blocks that read the encoder reference system i.e. whether axis is incremental or absolute
-		//Cycle through set position and MC_WritePArameter function blocks for each axis
-		afbReadEncRefSys[iCurrentAxis](
-			Axis := GVL.astAxes[iCurrentAxis].Axis,
-			ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
-			ReadMode := E_READMODE.READMODE_ONCE);
-			
-		IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
-			afbSetPosition[iCurrentAxis](
-				Axis := GVL.astAxes[iCurrentAxis].Axis,
-				Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown);
-		ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-			afbSetHomePosition[iCurrentAxis](
-				Axis := GVL.astAxes[iCurrentAxis].Axis,
-				Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown,
-				HomingMode := MC_HomingMode.MC_Direct);
-		END_IF
-		
-		afbWritePositionBias[iCurrentAxis](
-			Axis := GVL.astAxes[iCurrentAxis].Axis,
-			ParameterNumber := E_AxisParameters.AxisEncoderOffset,
-			Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
-	END_IF
+
+    IF NOT astAxes[iCurrentAxis].stStatus.bAxisInitialized OR NOT astAxesPersistent[iCurrentAxis].bHomedAtShutdown THEN
+        //If current axis has not been initialized or was not homed before power failure, perform position recovery for next axis
+        eStartUp := eNextAxis;
+    ELSE
+        //Cycle through function blocks that read the encoder reference system i.e. whether axis is incremental or absolute
+        //Cycle through set position and MC_WritePArameter function blocks for each axis
+        afbReadEncRefSys[iCurrentAxis](
+            Axis := GVL.astAxes[iCurrentAxis].Axis,
+            ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
+            ReadMode := E_READMODE.READMODE_ONCE);
+
+        IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+            afbSetPosition[iCurrentAxis](
+                Axis := GVL.astAxes[iCurrentAxis].Axis,
+                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown);
+        ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+            afbSetHomePosition[iCurrentAxis](
+                Axis := GVL.astAxes[iCurrentAxis].Axis,
+                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown,
+                HomingMode := MC_HomingMode.MC_Direct);
+        END_IF
+
+        afbWritePositionBias[iCurrentAxis](
+            Axis := GVL.astAxes[iCurrentAxis].Axis,
+            ParameterNumber := E_AxisParameters.AxisEncoderOffset,
+            Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
+    END_IF
 
     CASE eStartUp OF
         eColdStart:
@@ -222,116 +226,116 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
         eReadAxisFeedbackType:
             //Exectute the function blocks to read the encoder reference system (0=inc OR 1=ABS)
-			afbReadEncRefSys[iCurrentAxis].Enable := TRUE;
-			eStartUp := eCheckReadDone;
+            afbReadEncRefSys[iCurrentAxis].Enable := TRUE;
+            eStartUp := eCheckReadDone;
 
         eCheckReadDone:
             //Check the encoder reference system has been read for all axis -> if busy then continue with PLC cycle and check again next time.
             //If afbReadEncRefSys not started then go back a step.
             //If the current axis result in an error the code will get stuck here, this happens if GVL_APP.nAXIS_NUM is not set correctly
-			IF NOT afbReadEncRefSys[iCurrentAxis].Valid THEN
-				IF afbReadEncRefSys[iCurrentAxis].Busy THEN
-					//Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
-					RETURN;
-				ELSE
-					//Sometimes the code gets here and the afbReadEncRefSys[iCurrentAxis] misses the rising edge. If  the code gets here it means
-					//valid=FALSE and .busy=FALSE which indicateds the FB probably hasn't started and thus needs to see a rising edge.
-					//Set execute to low, Exit MAIN.STARTUP and go back a step in the CASE statement.
-					afbReadEncRefSys[iCurrentAxis].Enable := FALSE;
-					eStartUp := eReadAxisFeedbackType;
-					nRetry := nRetry + 1; //Counter used for troubleshooting to see how many cycles it takes before afbReadEncRefSys function blocks are read correctly
-					RETURN;
-				END_IF
-			END_IF
-          
+            IF NOT afbReadEncRefSys[iCurrentAxis].Valid THEN
+                IF afbReadEncRefSys[iCurrentAxis].Busy THEN
+                    //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+                    RETURN;
+                ELSE
+                    //Sometimes the code gets here and the afbReadEncRefSys[iCurrentAxis] misses the rising edge. If  the code gets here it means
+                    //valid=FALSE and .busy=FALSE which indicateds the FB probably hasn't started and thus needs to see a rising edge.
+                    //Set execute to low, Exit MAIN.STARTUP and go back a step in the CASE statement.
+                    afbReadEncRefSys[iCurrentAxis].Enable := FALSE;
+                    eStartUp := eReadAxisFeedbackType;
+                    nRetry := nRetry + 1; //Counter used for troubleshooting to see how many cycles it takes before afbReadEncRefSys function blocks are read correctly
+                    RETURN;
+                END_IF
+            END_IF
+
             //If the code gets here the current axis has .valid=TRUE
             eStartUp := eExecuteRestore;
 
         eExecuteRestore:
             //Execute position and encoder BIAS restore by setting Execute = TRUE
-			IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-				IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-					CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
-						INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
-							// Restore position value for incremental encoders
-							IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
-								afbSetPosition[iCurrentAxis].Execute := TRUE;
-							ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-								afbSetHomePosition[iCurrentAxis].Execute := TRUE;
-							END_IF
-						ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
-							// Restore encoder position BIAS for absolute encoders
-							afbWritePositionBias[iCurrentAxis].Execute := TRUE;
-					END_CASE
-				ELSE
-					RETURN;
-				END_IF
-			END_IF
-			
+            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
+                IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                    CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
+                        INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
+                            // Restore position value for incremental encoders
+                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+                                afbSetPosition[iCurrentAxis].Execute := TRUE;
+                            ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                                afbSetHomePosition[iCurrentAxis].Execute := TRUE;
+                            END_IF
+                        ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
+                            // Restore encoder position BIAS for absolute encoders
+                            afbWritePositionBias[iCurrentAxis].Execute := TRUE;
+                    END_CASE
+                ELSE
+                    RETURN;
+                END_IF
+            END_IF
+
             eStartUp := eCheckRestore;
 
         eCheckRestore:
             //Check the set position and write enocder BIAS fbs are finished
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
             //bPositionRestoreDone will never get set to TRUE and will take up cycle time
-        	IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-            	IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-                	CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF	
-						INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
-							IF afbSetPosition[iCurrentAxis].Busy THEN
-								//Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
-								RETURN;
-							END_IF 
-							
-							IF afbSetHomePosition[iCurrentAxis].Busy THEN
-								//Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
-								RETURN;
-							END_IF 
-							
-							IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
-								IF NOT afbSetPosition[iCurrentAxis].Done THEN
-									afbSetPosition[iCurrentAxis].Execute := FALSE;
-									eStartUp := eExecuteRestore;
-									RETURN;
-								END_IF
-							END_IF
-							
-							IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-								IF NOT afbSetHomePosition[iCurrentAxis].Done THEN
-									afbSetHomePosition[iCurrentAxis].Execute := FALSE;
-									eStartUp := eExecuteRestore;
-									RETURN;
-								END_IF
-							END_IF
-							
-						ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
-							IF NOT afbWritePositionBias[iCurrentAxis].Done THEN
-								afbWritePositionBias[iCurrentAxis].Execute := FALSE;
-								eStartUp := eExecuteRestore;
-                            	RETURN;
-							END_IF
-					END_CASE
+            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
+                IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                    CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
+                        INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
+                            IF afbSetPosition[iCurrentAxis].Busy THEN
+                                //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+                                RETURN;
+                            END_IF
+
+                            IF afbSetHomePosition[iCurrentAxis].Busy THEN
+                                //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+                                RETURN;
+                            END_IF
+
+                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+                                IF NOT afbSetPosition[iCurrentAxis].Done THEN
+                                    afbSetPosition[iCurrentAxis].Execute := FALSE;
+                                    eStartUp := eExecuteRestore;
+                                    RETURN;
+                                END_IF
+                            END_IF
+
+                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                                IF NOT afbSetHomePosition[iCurrentAxis].Done THEN
+                                    afbSetHomePosition[iCurrentAxis].Execute := FALSE;
+                                    eStartUp := eExecuteRestore;
+                                    RETURN;
+                                END_IF
+                            END_IF
+
+                        ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
+                            IF NOT afbWritePositionBias[iCurrentAxis].Done THEN
+                                afbWritePositionBias[iCurrentAxis].Execute := FALSE;
+                                eStartUp := eExecuteRestore;
+                                RETURN;
+                            END_IF
+                    END_CASE
                 END_IF
-			//ELSE
-				//RETURN;
-			END_IF
-          
-			afbSetHomePosition[iCurrentAxis].Execute := FALSE;
+            //ELSE
+                //RETURN;
+            END_IF
+
+            afbSetHomePosition[iCurrentAxis].Execute := FALSE;
             afbWritePositionBias[iCurrentAxis].Execute := FALSE;
             eStartUp := eNextAxis;
-		
-		eNextAxis:
-			iCurrentAxis := iCurrentAxis + 1;
-			IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
-				eStartUp := eRestoreFinished;
-				bPositionRestoreDone := TRUE;
-				bRestoreExecute := FALSE;
-			ELSE 
-				eStartUp := eReadAxisFeedbackType;
-			END_IF
-			
+
+        eNextAxis:
+            iCurrentAxis := iCurrentAxis + 1;
+            IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
+                eStartUp := eRestoreFinished;
+                bPositionRestoreDone := TRUE;
+                bRestoreExecute := FALSE;
+            ELSE
+                eStartUp := eReadAxisFeedbackType;
+            END_IF
+
         eRestoreFinished:
-			//Do nothing
+            //Do nothing
     END_CASE
 END_IF
 ]]></ST>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -146,7 +146,7 @@ Pneumatic_Box();
     </Action>
     <Action Name="RESTORE_POSITIONS" Id="{0c7ee537-7bd9-4833-b428-c17cbb57e893}" FolderPath="POSITION_RECOVERY\">
       <Implementation>
-        <ST><![CDATA[//This ACT will restore the position of an incremental axis on startup with the act position it read before losing power.
+        <ST><![CDATA[//This ACT will restore the position of an incremental axis on startup with the act position being read before losing power.
 //It checks the type of axis, 0=incremental, and that the axis was stationary at shut down.
 //Because 0 equates to incremental we also need to check that the data is valid, otherwise by default it would restore all axes.
 //By default an axis will not restore the position unless it is set to opt-in, i.e. GVL.aAxes[iAxes].stConfig.eRestorePosition is non-zero.
@@ -154,7 +154,8 @@ Pneumatic_Box();
 //A restore will only be performed on a loss of power, this code shouldn't make any changes on a reset cold, a rest origin or a download.
 //There is a enum to allow for different types of restore modes, currently only one is implemented.
 //0 'DontRestore'
-//1 'RestoreWithoutHome' -restores the position using a set position fb and does not set the home bit in the axis struct.
+//1 'RestoreWithoutHome' - Restores the position using a set position fb and does not set the home bit in the axis struct.
+//2 ''RestoreWithHome' - Restores the position using a set position fb and does set the home bit in the axis struct.
 //Note from Beckhoff: "A maximum of 1 MB persistent data can be reliably saved over the entire service life."
 //Encoder Reference system types: https://infosys.beckhoff.com/english.php?content=../content/1033/tf50x0_tc3_nc_ptp/3439907723.html&id=
 //INCREMENTAL=0;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -18,8 +18,9 @@ VAR
     bPositionRestoreDone: BOOL := FALSE;
     bRestoreExecute: BOOL := FALSE;
     bExecuteReadEncRefSys: BOOL := FALSE;
-    nRetry: INT; //A counter for startup actions
-    iAxes: UINT; //index for for loops in Position recovery actions
+    nRetry: INT; //Counter for startup actions
+    iAxes: UINT := 1; //Index for, for loops in position recovery actions
+	iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
     afbReadEncRefSys: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbSetHomePosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_Home;
     stHomingParameter: MC_HomingParameter;
@@ -166,38 +167,44 @@ IF bRestoreOnStartup AND eGlobalSUpsState = eSUPS_PowerOK THEN
     bRestoreOnStartup := FALSE;
     bRestoreExecute := TRUE;
     timeAsDTAtStartup := FILETIME64_TO_DT(F_GetSystemTime());
+	iCurrentAxis := 1;
+END_IF
 
-    FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-        IF NOT astAxes[iAxes].stStatus.bAxisInitialized THEN
-            //Do nothing if axis has not been initialized
-            RETURN;
-        END_IF
-    END_FOR
+IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN 
+	RETURN; 
 END_IF
 
 //Upon startup bPositionRestoreDone will be set to FALSE, after successfully completing the following code it will be set TRUE
 //and should stay TRUE for the rest of the time the PLC is operational, thus this routine should only be completed once.
 IF bRestoreExecute AND NOT bPositionRestoreDone THEN
-    //Cycle through function blocks that read the encoder reference system i.e. whether axis is incremental or absolute
-    FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-         afbReadEncRefSys[iAxes](
-            Axis := GVL.astAxes[iAxes].Axis,
-            ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
-            ReadMode := E_READMODE.READMODE_ONCE);
-    END_FOR
-
-    //Cycle through set position and MC_WritePArameter function blocks for each axis
-    FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-        afbSetHomePosition[iAxes](
-            Axis := GVL.astAxes[iAxes].Axis,
-            Position := astAxesPersistent[iAxes].fPositionAtShutdown,
-            HomingMode := MC_HomingMode.MC_Direct);
-
-        afbWritePositionBias[iAxes](
-            Axis := GVL.astAxes[iAxes].Axis,
-            ParameterNumber := E_AxisParameters.AxisEncoderOffset,
-            Value := astAxesPersistent[iAxes].fEncoderBiasAtShutdown);
-    END_FOR
+   
+	IF NOT astAxes[iCurrentAxis].stStatus.bAxisInitialized OR NOT astAxesPersistent[iCurrentAxis].bHomedAtShutdown THEN
+		//If current axis has not been initialized or was not homed before power failure, perform position recovery for next axis
+		eStartUp := eNextAxis;
+	ELSE
+		//Cycle through function blocks that read the encoder reference system i.e. whether axis is incremental or absolute
+		//Cycle through set position and MC_WritePArameter function blocks for each axis
+		afbReadEncRefSys[iCurrentAxis](
+			Axis := GVL.astAxes[iCurrentAxis].Axis,
+			ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
+			ReadMode := E_READMODE.READMODE_ONCE);
+			
+		IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+			afbSetPosition[iCurrentAxis](
+				Axis := GVL.astAxes[iCurrentAxis].Axis,
+				Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown);
+		ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+			afbSetHomePosition[iCurrentAxis](
+				Axis := GVL.astAxes[iCurrentAxis].Axis,
+				Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown,
+				HomingMode := MC_HomingMode.MC_Direct);
+		END_IF
+		
+		afbWritePositionBias[iCurrentAxis](
+			Axis := GVL.astAxes[iCurrentAxis].Axis,
+			ParameterNumber := E_AxisParameters.AxisEncoderOffset,
+			Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
+	END_IF
 
     CASE eStartUp OF
         eColdStart:
@@ -209,87 +216,95 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
         eReadAxisFeedbackType:
             //Exectute the function blocks to read the encoder reference system (0=inc OR 1=ABS)
-            FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                afbReadEncRefSys[iAxes].Enable := TRUE;
-                eStartUp := eCheckReadDone;
-            END_FOR
+			afbReadEncRefSys[iCurrentAxis].Enable := TRUE;
+			eStartUp := eCheckReadDone;
 
         eCheckReadDone:
             //Check the encoder reference system has been read for all axis -> if busy then continue with PLC cycle and check again next time.
             //If afbReadEncRefSys not started then go back a step.
-            //If any axes result in an error the code will get stuck here, this happens if GVL_APP.nAXIS_NUM is not set correctly
-            FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                IF NOT afbReadEncRefSys[iAxes].Valid THEN
-                    IF afbReadEncRefSys[iAxes].Busy THEN
-                        //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
-                        RETURN;
-                    ELSE
-                        //Sometimes the code gets here and the afbReadEncRefSys[iAxes] misses the rising edge. If  the code gets here it means
-                        //valid=FALSE and .busy=FALSE which indicateds the FB probably hasn't started and thus needs to see a rising edge.
-                        //Set execute to low, Exit MAIN.STARTUP and go back a step in the CASE statement.
-                        afbReadEncRefSys[iAxes].Enable := FALSE;
-                        eStartUp := eReadAxisFeedbackType;
-                        nRetry := nRetry + 1; //counter used for troubleshooting to see how many cycles it takes before afbReadEncRefSys function blocks are read correctly
-                        RETURN;
-                    END_IF
-                END_IF
-            END_FOR
-            //If the code gets here all axes have .valid=TRUE for all axes
+            //If the current axis result in an error the code will get stuck here, this happens if GVL_APP.nAXIS_NUM is not set correctly
+			IF NOT afbReadEncRefSys[iCurrentAxis].Valid THEN
+				IF afbReadEncRefSys[iCurrentAxis].Busy THEN
+					//Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+					RETURN;
+				ELSE
+					//Sometimes the code gets here and the afbReadEncRefSys[iCurrentAxis] misses the rising edge. If  the code gets here it means
+					//valid=FALSE and .busy=FALSE which indicateds the FB probably hasn't started and thus needs to see a rising edge.
+					//Set execute to low, Exit MAIN.STARTUP and go back a step in the CASE statement.
+					afbReadEncRefSys[iCurrentAxis].Enable := FALSE;
+					eStartUp := eReadAxisFeedbackType;
+					nRetry := nRetry + 1; //Counter used for troubleshooting to see how many cycles it takes before afbReadEncRefSys function blocks are read correctly
+					RETURN;
+				END_IF
+			END_IF
+          
+            //If the code gets here the current axis has .valid=TRUE
             eStartUp := eExecuteRestore;
 
         eExecuteRestore:
             //Execute position and encoder BIAS restore by setting Execute = TRUE
-           FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR
-                    GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-                    //Restore position value for incremental encoders
-                    IF NOT astAxesPersistent[iAxes].bMovingAtShutdown AND
-                    (afbReadEncRefSys[iAxes].Value = 0 OR
-                     afbReadEncRefSys[iAxes].Value = 2 OR
-                     afbReadEncRefSys[iAxes].Value = 4) THEN
-                       afbSetHomePosition[iAxes].Execute := TRUE;
-                    //Restore encoder position BIAS for absolute encoders
-                    ELSIF afbReadEncRefSys[iAxes].Value = 1 OR
-                    afbReadEncRefSys[iAxes].Value = 3 OR
-                    afbReadEncRefSys[iAxes].Value = 5 THEN
-                       afbWritePositionBias[iAxes].Execute := TRUE;
-                    END_IF
-                ELSE
-                    RETURN;
-                END_IF
-            END_FOR
+			IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
+				IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+					CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
+						INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
+							// Restore position value for incremental encoders
+							IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+								afbSetPosition[iCurrentAxis].Execute := TRUE;
+							ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+								afbSetHomePosition[iCurrentAxis].Execute := TRUE;
+							END_IF
+						ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
+							// Restore encoder position BIAS for absolute encoders
+							afbWritePositionBias[iCurrentAxis].Execute := TRUE;
+					END_CASE
+				ELSE
+					RETURN;
+				END_IF
+			END_IF
+			
             eStartUp := eCheckRestore;
 
         eCheckRestore:
             //Check the set position and write enocder BIAS fbs are finished
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
             //bPositionRestoreDone will never get set to TRUE and will take up cycle time
-            FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR
-                    GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-                    IF NOT astAxesPersistent[iAxes].bMovingAtShutdown AND
-                    (afbReadEncRefSys[iAxes].Value = 0 OR
-                     afbReadEncRefSys[iAxes].Value = 2 OR
-                     afbReadEncRefSys[iAxes].Value = 4) THEN
-                        IF afbSetHomePosition[iAxes].Busy THEN
-                             //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
-                             RETURN;
-                        ELSIF NOT afbSetHomePosition[iAxes].Done THEN
-                                afbSetHomePosition[iAxes].Execute := FALSE;
-                                eStartUp := eExecuteRestore;
-                                RETURN;
-                        END_IF
-                    ELSIF afbReadEncRefSys[iAxes].Value = 1 OR
-                     afbReadEncRefSys[iAxes].Value = 3 OR
-                     afbReadEncRefSys[iAxes].Value = 5 THEN
-                        IF NOT afbWritePositionBias[iAxes].Done THEN
-                            afbWritePositionBias[iAxes].Execute := FALSE;
-                            eStartUp := eExecuteRestore;
-                            RETURN;
-                        END_IF
-                    END_IF
-                ELSE
-                    RETURN;
+        	IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
+            	IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                	CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF	
+						INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
+							IF afbSetPosition[iCurrentAxis].Busy THEN
+								//Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+								RETURN;
+							END_IF 
+							
+							IF afbSetHomePosition[iCurrentAxis].Busy THEN
+								//Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+								RETURN;
+							END_IF 
+							
+							IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+								IF NOT afbSetPosition[iCurrentAxis].Done THEN
+									afbSetPosition[iCurrentAxis].Execute := FALSE;
+									eStartUp := eExecuteRestore;
+									RETURN;
+								END_IF
+							END_IF
+							
+							IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+								IF NOT afbSetHomePosition[iCurrentAxis].Done THEN
+									afbSetHomePosition[iCurrentAxis].Execute := FALSE;
+									eStartUp := eExecuteRestore;
+									RETURN;
+								END_IF
+							END_IF
+							
+						ABSOLUTE, ABSOLUTE_MULTITURN_RANGE, ABSOLUTE_SINGLETURN_RANGE:
+							IF NOT afbWritePositionBias[iCurrentAxis].Done THEN
+								afbWritePositionBias[iCurrentAxis].Execute := FALSE;
+								eStartUp := eExecuteRestore;
+                            	RETURN;
+							END_IF
+					END_CASE
                 END_IF
 			//ELSE
 				//RETURN;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -106,11 +106,9 @@ IF eGlobalSUpsState = eSUPS_PowerFailure THEN
     //Execute code that should only be done once with each powerfailure, i.e. increase powerfailure counter
     bRestoreOnStartup := TRUE;
     STORE_PERSISTENT();
-    RETURN;
 ELSIF eGlobalSUpsState <> eSUPS_PowerOK THEN
     //Next cycles of powerfailure
     //Skip regular code execution for the remaining cycles of the powerfailure/writing of persistent data/quick shutdown...
-    RETURN;
 END_IF
 ]]></ST>
       </Implementation>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -7,6 +7,7 @@ VAR
     aIAxes: ARRAY [1..GVL_APP.nAXIS_NUM] OF I_Axis; //Array of axis interfaces, size determined by the total number of axes in the system
     afbAxes: ARRAY [1..GVL_APP.nAXIS_NUM] OF FB_Axis; //Array of axis function blocks, one for each axis
     afbPneumaticAxes: ARRAY [1..GVL_APP.nPNEUMATIC_AXIS_NUM] OF FB_PneumaticAxis; //Array of pneumatic axis function blocks, size determined by the number of pneumatic axes
+    afCurrentPosition: ARRAY [1..GVL_APP.nAXIS_NUM] OF LREAL; //Stores the current position of each axis at defined time intervals, see timeReadPosition
     hmiAxisSelection: INT := 1; //Specifies the currently selected axis for HMI operations, allowing the user to control a specific axis
     hmiPneumaticAxisSelection: INT := 1; //Specifies the currently selected pneumatic axis for HMI operation, allowing the user to control the specific axis
 
@@ -29,6 +30,12 @@ VAR
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
     timeAsDTAtStartup: DT;
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
+
+    //Read position at a specific time interval
+    tonReadPosition: TON;
+    bReadPosition: BOOL:= TRUE;
+    timeReadPosition: TIME := T#5S; //Interval time
+    fPositionDifferenceLimit: LREAL := 0.001; //The acceptable difference between the sampled position and position at shutdown
 END_VAR
 VAR CONSTANT
     INCREMENTAL: UINT := 0;
@@ -119,7 +126,22 @@ END_IF
     </Action>
     <Action Name="POSITION_RECOVERY" Id="{28e203b7-aea5-42d0-980d-12a6841f9d22}" FolderPath="POSITION_RECOVERY\">
       <Implementation>
-        <ST><![CDATA[fbGetDeviceIdentification(bExecute := TRUE);
+        <ST><![CDATA[tonReadPosition(IN := bReadPosition, PT := timeReadPosition);
+
+IF tonReadPosition.Q THEN
+    FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
+        afCurrentPosition[iAxes] := GVL.astAxes[iAxes].Axis.NcToPlc.ActPos;
+    END_FOR
+    bReadPosition := FALSE;
+END_IF
+
+IF NOT bReadPosition AND NOT tonReadPosition.Q THEN
+    // After timer has reset, turn it on again
+    bReadPosition := TRUE;
+END_IF
+
+
+fbGetDeviceIdentification(bExecute := TRUE);
 IF (fbGetDeviceIdentification.stDevIdent.strHardwareSerialNo <> '') THEN
     CHECK_UPS();
     RESTORE_POSITIONS();
@@ -356,7 +378,7 @@ END_IF
     astAxesPersistent[iAxes].bHomedAtShutdown := GVL.astAxes[iAxes].stStatus.bHomed;
 
     //Store value of moving at shutdown
-    IF GVL.astAxes[iAxes].Axis.Status.StandStill OR GVL.astAxes[iAxes].Axis.Status.Disabled THEN
+    IF GVL.astAxes[iAxes].Axis.Status.Disabled OR astAxesPersistent[iAxes].fPositionDifference < fPositionDifferenceLimit THEN
         astAxesPersistent[iAxes].bMovingAtShutdown := FALSE;
     ELSE
         astAxesPersistent[iAxes].bMovingAtShutdown := TRUE;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -16,10 +16,10 @@ VAR
     fbC6017UPS: FB_S_UPS_BAPI;
     eSelUpsMode: E_S_UPS_Mode := eSUPS_WrPersistData_Shutdown; //Selected UPS mode
     eStartUp: (eColdStart, eReadAxisFeedbackType, eCheckReadDone, eExecuteRestore, eCheckRestore, eNextAxis, eRestoreFinished);
+
     bPositionRestoreDone: BOOL := FALSE;
     bRestoreExecute: BOOL := FALSE;
-    bExecuteReadEncRefSys: BOOL := FALSE;
-    nRetry: INT; //A counter for startup actions
+    nRetry: INT := 0; //Counts number of retries to read encoder reference
     iAxes: UINT; //Index for, for-loops in position recovery actions
     iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
 
@@ -31,17 +31,18 @@ VAR
 
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
     timeAsDTAtStartup: DT;
-    nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
+    nTestNum: UINT := 0; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 
     //Read position at a specific time interval
     fbReadPositionTimer: TON;
-    bReadPosition: BOOL:= TRUE;
+    bReadPosition: BOOL := TRUE;
     tReadPosition: TIME := T#5S; //Interval time
     fPositionDifferenceLimit: LREAL := 0.001; //The acceptable difference between the sampled position and position at shutdown
 END_VAR
 VAR PERSISTENT
     bRestoreOnStartup: BOOL; //Determines whether the axis positions should be restored automatically during system startup
 END_VAR
+
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[POSITION_RECOVERY();
@@ -97,7 +98,6 @@ END_FOR
 END_CASE
 
 FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-    //Read the encoder position bias for initialized axes
     IF astAxes[iAxes].stStatus.bAxisInitialized THEN
         afbReadPositionBias[iAxes](Axis := GVL.astAxes[iAxes].Axis,
                         Enable := TRUE,
@@ -105,6 +105,7 @@ FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
                         ParameterNumber := E_AxisParameters.AxisEncoderOffset);
     END_IF
 END_FOR
+
 
 IF eGlobalSUpsState = eSUPS_PowerFailure THEN
     //First cycle of powerfailure
@@ -169,36 +170,27 @@ Pneumatic_Box();
     </Action>
     <Action Name="RESTORE_POSITIONS" Id="{0c7ee537-7bd9-4833-b428-c17cbb57e893}" FolderPath="POSITION_RECOVERY\">
       <Implementation>
-        <ST><![CDATA[//This ACT will restore the position of an incremental axis on startup with the act position being read before losing power.
-//It checks the type of axis, 0=incremental, and that the axis was stationary at shut down.
-//Because 0 equates to incremental we also need to check that the data is valid, otherwise by default it would restore all axes.
-//By default an axis will not restore the position unless it is set to opt-in, i.e. GVL.aAxes[iAxes].stConfig.eRestorePosition is non-zero.
-//This needs to be initialised somewhere in TwinCAT code otherwise it will not be available at start up.
-//A restore will only be performed on a loss of power, this code shouldn't make any changes on a reset cold, a rest origin or a download.
-//There is a enum to allow for different types of restore modes, currently only one is implemented.
-//0 'DontRestore'
-//1 'RestoreWithoutHome' - Restores the position using a set position fb and does not set the home bit in the axis struct.
-//2 'RestoreWithHome' - Restores the position using a set position fb and does set the home bit in the axis struct.
-//Note from Beckhoff: "A maximum of 1 MB persistent data can be reliably saved over the entire service life."
-//Encoder Reference system types: https://infosys.beckhoff.com/english.php?content=../content/1033/tf50x0_tc3_nc_ptp/3439907723.html&id=
-//INCREMENTAL=0;
-//ABSOLUTE=1;
-//ABSOLUTE (modulo)=2;
-//ABSOLUTE MULTITURN RANGE (with single overflow)=3;
-//INCREMENTAL (singleturn absolute)=4;
-//ABSOLUTE SINGLETURN RANGE (with single overflow)=5;
-
+        <ST><![CDATA[(*
+This ACT will restore the position of an incremental axis and the position bias of an absolute axis on startup,
+with the actual position and position bias being read before losing power. It checks the type of axis, 0=incremental,
+and that the axis was stationary at shut down. Because 0 equates to incremental we also need to check that the data is valid,
+otherwise by default it would restore all axes. A restore will only be performed on a loss of power,
+this code shouldn't make any changes on a reset cold, a rest origin or a download.
+Note from Beckhoff: "A maximum of 1 MB persistent data can be reliably saved over the entire service life."
+*)
 
 IF bRestoreOnStartup AND eGlobalSUpsState = eSUPS_PowerOK THEN
     bRestoreOnStartup := FALSE;
     bRestoreExecute := TRUE;
     timeAsDTAtStartup := FILETIME64_TO_DT(F_GetSystemTime());
     iCurrentAxis := 1;
+
 END_IF
 
 IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
     RETURN;
 END_IF
+
 
 //Upon startup bPositionRestoreDone will be set to FALSE, after successfully completing the following code it will be set TRUE
 //and should stay TRUE for the rest of the time the PLC is operational, thus this routine should only be completed once.
@@ -249,29 +241,24 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             eStartUp := eCheckReadDone;
 
         eCheckReadDone:
-            //Check the encoder reference system has been read for all axis -> if busy then continue with PLC cycle and check again next time.
-            //If afbReadEncRefSys not started then go back a step.
-            //If the current axis result in an error the code will get stuck here, this happens if GVL_APP.nAXIS_NUM is not set correctly
-            IF NOT afbReadEncRefSys[iCurrentAxis].Valid THEN
-                IF afbReadEncRefSys[iCurrentAxis].Busy THEN
-                    //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+            //Check that the encoder reference system has been read for the current axis -> if busy then continue with PLC cycle and check again next time.
+            IF NOT fbReadEncRefSys.Valid THEN
+                IF fbReadEncRefSys.Busy THEN
                     RETURN;
                 ELSE
-                    //Sometimes the code gets here and the afbReadEncRefSys[iCurrentAxis] misses the rising edge. If  the code gets here it means
-                    //valid=FALSE and .busy=FALSE which indicateds the FB probably hasn't started and thus needs to see a rising edge.
-                    //Set execute to low, Exit MAIN.STARTUP and go back a step in the CASE statement.
-                    afbReadEncRefSys[iCurrentAxis].Enable := FALSE;
+                    //.Valid=FALSE and .Busy=FALSE which indicateds the FB probably hasn't started and thus needs to see a rising edge.
+                    //Set .Enable=FALSE and go back a step in the CASE statement.
+                    nRetry := nRetry + 1;
+                    fbReadEncRefSys.Enable := FALSE;
                     eStartUp := eReadAxisFeedbackType;
                     nRetry := nRetry + 1; //Counter used for troubleshooting to see how many cycles it takes before afbReadEncRefSys function blocks are read correctly
                     RETURN;
                 END_IF
             END_IF
 
-            //If the code gets here the current axis has .valid=TRUE
             eStartUp := eExecuteRestore;
 
         eExecuteRestore:
-            //Execute position and encoder BIAS restore by setting Execute = TRUE
             IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
                 CASE LREAL_TO_INT(fbReadEncRefSys.Value) OF
 
@@ -292,7 +279,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             eStartUp := eCheckRestore;
 
         eCheckRestore:
-            //Check the set position and write enocder BIAS fbs are finished
+            //Check that the set position and write encoder bias fbs are finished
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
             //bPositionRestoreDone will never get set to TRUE and will take up cycle time
             IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
@@ -363,6 +350,7 @@ END_IF
 
     //Store encoder position BIAS at shutdown
     astAxesPersistent[iAxes].fEncoderBiasAtShutdown := afbReadPositionBias[iAxes].Value;
+
 
     //Store axis status at shutdown
     astAxesPersistent[iAxes].bInitializedAtShutdown := GVL.astAxes[iAxes].stStatus.bAxisInitialized;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -7,7 +7,7 @@ VAR
     aIAxes: ARRAY [1..GVL_APP.nAXIS_NUM] OF I_Axis; //Array of axis interfaces, size determined by the total number of axes in the system
     afbAxes: ARRAY [1..GVL_APP.nAXIS_NUM] OF FB_Axis; //Array of axis function blocks, one for each axis
     afbPneumaticAxes: ARRAY [1..GVL_APP.nPNEUMATIC_AXIS_NUM] OF FB_PneumaticAxis; //Array of pneumatic axis function blocks, size determined by the number of pneumatic axes
-    afCurrentPosition: ARRAY [1..GVL_APP.nAXIS_NUM] OF LREAL; //Stores the current position of each axis at defined time intervals, see timeReadPosition
+    afSavedPosition: ARRAY [1..GVL_APP.nAXIS_NUM] OF LREAL; //Stores the current position of each axis at defined time intervals, see tReadPosition
     hmiAxisSelection: INT := 1; //Specifies the currently selected axis for HMI operations, allowing the user to control a specific axis
     hmiPneumaticAxisSelection: INT := 1; //Specifies the currently selected pneumatic axis for HMI operation, allowing the user to control the specific axis
 
@@ -126,7 +126,7 @@ END_IF
 
 IF fbReadPositionTimer.Q THEN
     FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-        afCurrentPosition[iAxes] := GVL.astAxes[iAxes].Axis.NcToPlc.ActPos;
+        afSavedPosition[iAxes] := GVL.astAxes[iAxes].Axis.NcToPlc.ActPos;
     END_FOR
     bReadPosition := FALSE;
 END_IF
@@ -367,7 +367,7 @@ END_IF
     //Store axis status at shutdown
     astAxesPersistent[iAxes].bInitializedAtShutdown := GVL.astAxes[iAxes].stStatus.bAxisInitialized;
     astAxesPersistent[iAxes].bHomedAtShutdown := GVL.astAxes[iAxes].stStatus.bHomed;
-    astAxesPersistent[iAxes].fPositionDifferenceAtShutdown := ABS(afCurrentPosition[iAxes] - astAxesPersistent[iAxes].fPositionAtShutdown);
+    astAxesPersistent[iAxes].fPositionDifferenceAtShutdown := ABS(afSavedPosition[iAxes] - astAxesPersistent[iAxes].fPositionAtShutdown);
 
     //Store value of moving at shutdown
     IF astAxes[iAxes].Axis.Status.Disabled OR astAxesPersistent[iAxes].fPositionDifferenceAtShutdown < fPositionDifferenceLimit THEN

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -23,12 +23,20 @@ VAR
 	iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
     afbReadEncRefSys: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbSetHomePosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_Home;
-    stHomingParameter: MC_HomingParameter;
+	afbSetPosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_SetPosition;
     afbReadPositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbWritePositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_WriteParameter;
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
     timeAsDTAtStartup: DT;
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
+END_VAR
+VAR CONSTANT
+	INCREMENTAL: UINT := 0;
+	ABSOLUTE: UINT := 1;
+	ABSOLUTE_MODULO: UINT := 2;
+	ABSOLUTE_MULTITURN_RANGE: UINT := 3; //(with single overflow)
+	INCREMENTAL_SINGLETURN_ABSOLUTE: UINT := 4;
+	ABSOLUTE_SINGLETURN_RANGE: UINT :=5; //(with single overflow)
 END_VAR
 VAR PERSISTENT
     bRestoreOnStartup: BOOL; //Determines whether the axis positions should be restored automatically during system startup

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -25,10 +25,10 @@ VAR
     afbReadPositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbWritePositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_WriteParameter;
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
-	fbSystemTime : GETSYSTEMTIME;
+    fbSystemTime : GETSYSTEMTIME;
     timeAsFileTime : T_FILETIME;
     timeAsDT : DT;
-	timeAsDTAtStartup : DT;
+    timeAsDTAtStartup : DT;
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 END_VAR
 
@@ -99,7 +99,7 @@ IF eGlobalSUpsState = eSUPS_PowerFailure THEN
     //First cycle of powerfailure
     //Execute code that should only be done once with each powerfailure, i.e. increase powerfailure counter
     bRestoreOnStartup := TRUE;
-	SYSTEM_TIME();
+    SYSTEM_TIME();
     STORE_PERSISTENT();
     RETURN;
 ELSIF eGlobalSUpsState <> eSUPS_PowerOK THEN
@@ -167,17 +167,17 @@ Pneumatic_Box();
 
 
 IF bRestoreOnStartup AND eGlobalSUpsState = eSUPS_PowerOK THEN
-	bRestoreOnStartup := FALSE;
-	bRestoreExecute := TRUE;
-	SYSTEM_TIME();
-	timeAsDTAtStartup := timeAsDT;
+    bRestoreOnStartup := FALSE;
+    bRestoreExecute := TRUE;
+    SYSTEM_TIME();
+    timeAsDTAtStartup := timeAsDT;
 
-	FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-		IF NOT astAxes[iAxes].stStatus.bAxisInitialized THEN
-			//Do nothing if axis has not been initialized
-			RETURN;
-		END_IF
-	END_FOR
+    FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
+        IF NOT astAxes[iAxes].stStatus.bAxisInitialized THEN
+            //Do nothing if axis has not been initialized
+            RETURN;
+        END_IF
+    END_FOR
 END_IF
 
 //Upon startup bPositionRestoreDone will be set to FALSE, after successfully completing the following code it will be set TRUE
@@ -244,8 +244,8 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
         eExecuteRestore:
             //Execute position and encoder BIAS restore by setting Execute = TRUE
            FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR 
-					GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR
+                    GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
                     //Restore position value for incremental encoders
                     IF NOT astAxesPersistent[iAxes].bMovingAtShutdown AND
                     (afbReadEncRefSys[iAxes].Value = 0 OR
@@ -270,21 +270,21 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
             //bPositionRestoreDone will never get set to TRUE and will take up cycle time
             FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR  
-					GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR
+                    GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
                     IF NOT astAxesPersistent[iAxes].bMovingAtShutdown AND
                     (afbReadEncRefSys[iAxes].Value = 0 OR
                      afbReadEncRefSys[iAxes].Value = 2 OR
                      afbReadEncRefSys[iAxes].Value = 4) THEN
-						 IF afbSetPosition[iAxes].Busy THEN
-							 //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
-							 RETURN;
-						 END_IF
-							IF NOT afbSetPosition[iAxes].Done THEN
-								afbSetPosition[iAxes].Execute := FALSE;
-								eStartUp := eExecuteRestore;
-								RETURN;
-							END_IF
+                         IF afbSetPosition[iAxes].Busy THEN
+                             //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
+                             RETURN;
+                         END_IF
+                            IF NOT afbSetPosition[iAxes].Done THEN
+                                afbSetPosition[iAxes].Execute := FALSE;
+                                eStartUp := eExecuteRestore;
+                                RETURN;
+                            END_IF
                      ELSIF afbReadEncRefSys[iAxes].Value = 1 OR
                      afbReadEncRefSys[iAxes].Value = 3 OR
                      afbReadEncRefSys[iAxes].Value = 5 THEN
@@ -307,11 +307,11 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                 afbWritePositionBias[iAxes].Execute := FALSE;
                 bPositionRestoreDone := TRUE;
                 bRestoreExecute := FALSE;
-				IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-					GVL.astAxes[iAxes].stControl.bEnable := TRUE;
-					GVL.astAxes[iAxes].stControl.eCommand := E_MotionFunctions.eHome;
-					GVL.astAxes[iAxes].stControl.bExecute := TRUE;
-				END_IF
+                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                    GVL.astAxes[iAxes].stControl.bEnable := TRUE;
+                    GVL.astAxes[iAxes].stControl.eCommand := E_MotionFunctions.eHome;
+                    GVL.astAxes[iAxes].stControl.bExecute := TRUE;
+                END_IF
             END_FOR
     END_CASE
 END_IF
@@ -343,7 +343,7 @@ GVL.timeAtShutdownPersistent := timeAsDT;
     <Action Name="SYSTEM_TIME" Id="{ed24f670-0ba1-0f6e-340a-0db7ff2026cb}">
       <Implementation>
         <ST><![CDATA[fbSystemTime(timeLoDW => timeAsFileTime.dwLowDateTime, timeHiDW => timeAsFileTime.dwHighDateTime);
-timeAsDT := FILETIME_TO_DT(timeAsFileTime); 
+timeAsDT := FILETIME_TO_DT(timeAsFileTime);
 
 ]]></ST>
       </Implementation>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -371,22 +371,12 @@ END_IF
     astAxesPersistent[iAxes].fEncoderBiasAtShutdown := afbReadPositionBias[iAxes].Value;
 
     //Store axis status at shutdown
-    astAxesPersistent[iAxes].bInitialized := GVL.astAxes[iAxes].stStatus.bAxisInitialized;
+    astAxesPersistent[iAxes].bInitializedAtShutdown := GVL.astAxes[iAxes].stStatus.bAxisInitialized;
     astAxesPersistent[iAxes].bHomedAtShutdown := GVL.astAxes[iAxes].stStatus.bHomed;
-    astAxesPersistent[iAxes].stMotionState := GVL.astAxes[iAxes].Axis.Status.MotionState;
-    astAxesPersistent[iAxes].bError := GVL.astAxes[iAxes].Axis.Status.Error;
-    astAxesPersistent[iAxes].nErrorID := GVL.astAxes[iAxes].Axis.Status.ErrorID;
-    astAxesPersistent[iAxes].bErrorStop := GVL.astAxes[iAxes].Axis.Status.ErrorStop;
-    astAxesPersistent[iAxes].bStandStill := GVL.astAxes[iAxes].Axis.Status.StandStill;
-    astAxesPersistent[iAxes].bHasBeenStopped := GVL.astAxes[iAxes].Axis.Status.HasBeenStopped;
-    astAxesPersistent[iAxes].bDisabled := GVL.astAxes[iAxes].Axis.Status.Disabled;
-    astAxesPersistent[iAxes].bMoving := GVL.astAxes[iAxes].Axis.Status.Moving;
-
-    astAxesPersistent[iAxes].nCycles := astAxesPersistent[iAxes].nCycles + 1;
-    astAxesPersistent[iAxes].fPositionDifference := ABS(afCurrentPosition[iAxes] - astAxesPersistent[iAxes].fPositionAtShutdown);
+    astAxesPersistent[iAxes].fPositionDifferenceAtShutdown := ABS(afCurrentPosition[iAxes] - astAxesPersistent[iAxes].fPositionAtShutdown);
 
     //Store value of moving at shutdown
-    IF GVL.astAxes[iAxes].Axis.Status.Disabled OR astAxesPersistent[iAxes].fPositionDifference < fPositionDifferenceLimit THEN
+    IF astAxes[iAxes].Axis.Status.Disabled OR astAxesPersistent[iAxes].fPositionDifferenceAtShutdown < fPositionDifferenceLimit THEN
         astAxesPersistent[iAxes].bMovingAtShutdown := FALSE;
     ELSE
         astAxesPersistent[iAxes].bMovingAtShutdown := TRUE;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -310,11 +310,14 @@ END_IF
     <Action Name="STORE_PERSISTENT" Id="{cb5c9254-2e5f-47b1-9baa-10e728a961b0}" FolderPath="POSITION_RECOVERY\">
       <Implementation>
         <ST><![CDATA[FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-    //Store Position at shutdown
+    //Store actual position at shutdown
     astAxesPersistent[iAxes].fPositionAtShutdown := GVL.astAxes[iAxes].Axis.NcToPlc.ActPos;
 
     //Store encoder position BIAS at shutdown
     astAxesPersistent[iAxes].fEncoderBiasAtShutdown := afbReadPositionBias[iAxes].Value;
+
+    //Store homing status at shutdown
+    astAxesPersistent[iAxes].bHomedAtShutdown := GVL.astAxes[iAxes].stStatus.bHomed;
 
     //Store value of moving at shutdown
     IF GVL.astAxes[iAxes].Axis.Status.StandStill OR GVL.astAxes[iAxes].Axis.Status.Disabled THEN

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -13,7 +13,7 @@ VAR
 //Startup, Shutdown and UPS
     fbCX5130UPS: FB_S_UPS_CX51x0;
     fbC6017UPS: FB_S_UPS_BAPI;
-    eUpsMode: E_S_UPS_Mode := eSUPS_WrPersistData_Shutdown;
+    eSelUpsMode: E_S_UPS_Mode := eSUPS_WrPersistData_Shutdown; //Selected UPS mode
     eStartUp: (eColdStart, eReadAxisFeedbackType, eCheckReadDone, eExecuteRestore, eCheckRestore, eFinishRestore);
     bPositionRestoreDone: BOOL := FALSE;
     bRestoreExecute: BOOL := FALSE;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -25,10 +25,7 @@ VAR
     afbReadPositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbWritePositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_WriteParameter;
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
-    fbSystemTime : GETSYSTEMTIME;
-    timeAsFileTime : T_FILETIME;
-    timeAsDT : DT;
-    timeAsDTAtStartup : DT;
+    timeAsDTAtStartup: DT;
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 END_VAR
 
@@ -99,7 +96,6 @@ IF eGlobalSUpsState = eSUPS_PowerFailure THEN
     //First cycle of powerfailure
     //Execute code that should only be done once with each powerfailure, i.e. increase powerfailure counter
     bRestoreOnStartup := TRUE;
-    SYSTEM_TIME();
     STORE_PERSISTENT();
     RETURN;
 ELSIF eGlobalSUpsState <> eSUPS_PowerOK THEN
@@ -169,8 +165,7 @@ Pneumatic_Box();
 IF bRestoreOnStartup AND eGlobalSUpsState = eSUPS_PowerOK THEN
     bRestoreOnStartup := FALSE;
     bRestoreExecute := TRUE;
-    SYSTEM_TIME();
-    timeAsDTAtStartup := timeAsDT;
+    timeAsDTAtStartup := FILETIME64_TO_DT(F_GetSystemTime());
 
     FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
         IF NOT astAxes[iAxes].stStatus.bAxisInitialized THEN
@@ -336,15 +331,7 @@ END_IF
 END_FOR
 
 //Store date and time at shutdown
-GVL.timeAtShutdownPersistent := timeAsDT;
-]]></ST>
-      </Implementation>
-    </Action>
-    <Action Name="SYSTEM_TIME" Id="{ed24f670-0ba1-0f6e-340a-0db7ff2026cb}">
-      <Implementation>
-        <ST><![CDATA[fbSystemTime(timeLoDW => timeAsFileTime.dwLowDateTime, timeHiDW => timeAsFileTime.dwHighDateTime);
-timeAsDT := FILETIME_TO_DT(timeAsFileTime);
-
+GVL.timeAtShutdownPersistent := FILETIME64_TO_DT(F_GetSystemTime());
 ]]></ST>
       </Implementation>
     </Action>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -33,9 +33,9 @@ VAR
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 
     //Read position at a specific time interval
-    tonReadPosition: TON;
+    fbReadPositionTimer: TON;
     bReadPosition: BOOL:= TRUE;
-    timeReadPosition: TIME := T#5S; //Interval time
+    tReadPosition: TIME := T#5S; //Interval time
     fPositionDifferenceLimit: LREAL := 0.001; //The acceptable difference between the sampled position and position at shutdown
 END_VAR
 VAR CONSTANT
@@ -127,16 +127,16 @@ END_IF
     </Action>
     <Action Name="POSITION_RECOVERY" Id="{28e203b7-aea5-42d0-980d-12a6841f9d22}" FolderPath="POSITION_RECOVERY\">
       <Implementation>
-        <ST><![CDATA[tonReadPosition(IN := bReadPosition, PT := timeReadPosition);
+        <ST><![CDATA[fbReadPositionTimer(IN := bReadPosition, PT := tReadPosition);
 
-IF tonReadPosition.Q THEN
+IF fbReadPositionTimer.Q THEN
     FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
         afCurrentPosition[iAxes] := GVL.astAxes[iAxes].Axis.NcToPlc.ActPos;
     END_FOR
     bReadPosition := FALSE;
 END_IF
 
-IF NOT bReadPosition AND NOT tonReadPosition.Q THEN
+IF NOT bReadPosition AND NOT fbReadPositionTimer.Q THEN
     // After timer has reset, turn it on again
     bReadPosition := TRUE;
 END_IF

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -188,33 +188,35 @@ END_IF
 //and should stay TRUE for the rest of the time the PLC is operational, thus this routine should only be completed once.
 IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
-    IF NOT astAxes[iCurrentAxis].stStatus.bAxisInitialized OR NOT astAxesPersistent[iCurrentAxis].bHomedAtShutdown THEN
-        //If current axis has not been initialized or was not homed before power failure, perform position recovery for next axis
-        eStartUp := eNextAxis;
-    ELSE
+//  //If current axis has not been initialized properly or was not homed before power failure, perform position recovery for next axis
+//    IF NOT astAxes[iCurrentAxis].stStatus.bAxisInitialized OR NOT astAxesPersistent[iCurrentAxis].bHomedAtShutdown THEN
+//        eStartUp := eNextAxis;
+//    ELSE
         //Cycle through function blocks that read the encoder reference system i.e. whether axis is incremental or absolute
         //Cycle through set position and MC_WritePArameter function blocks for each axis
-        afbReadEncRefSys[iCurrentAxis](
-            Axis := GVL.astAxes[iCurrentAxis].Axis,
-            ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
-            ReadMode := E_READMODE.READMODE_ONCE);
+        FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
+            afbReadEncRefSys[iAxes](
+                Axis := GVL.astAxes[iAxes].Axis,
+                ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
+                ReadMode := E_READMODE.READMODE_ONCE);
 
-        IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
-            afbSetPosition[iCurrentAxis](
-                Axis := GVL.astAxes[iCurrentAxis].Axis,
-                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown);
-        ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
-            afbSetHomePosition[iCurrentAxis](
-                Axis := GVL.astAxes[iCurrentAxis].Axis,
-                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown,
-                HomingMode := MC_HomingMode.MC_Direct);
-        END_IF
+            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+                afbSetPosition[iAxes](
+                    Axis := GVL.astAxes[iAxes].Axis,
+                    Position := astAxesPersistent[iAxes].fPositionAtShutdown);
+            ELSIF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                afbSetHomePosition[iAxes](
+                    Axis := GVL.astAxes[iAxes].Axis,
+                    Position := astAxesPersistent[iAxes].fPositionAtShutdown,
+                    HomingMode := MC_HomingMode.MC_Direct);
+            END_IF
 
-        afbWritePositionBias[iCurrentAxis](
-            Axis := GVL.astAxes[iCurrentAxis].Axis,
-            ParameterNumber := E_AxisParameters.AxisEncoderOffset,
-            Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
-    END_IF
+            afbWritePositionBias[iAxes](
+                Axis := GVL.astAxes[iAxes].Axis,
+                ParameterNumber := E_AxisParameters.AxisEncoderOffset,
+                Value := astAxesPersistent[iAxes].fEncoderBiasAtShutdown);
+        END_FOR
+//    END_IF
 
     CASE eStartUp OF
         eColdStart:

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -31,7 +31,7 @@ VAR
     fbWritePositionBias: MC_WriteParameter;
 
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
-    timeAsDTAtStartup: DT;
+    dtAtStartup: DT;
     nTestNum: UINT := 0; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 
     //Read position at a specific time interval
@@ -182,7 +182,7 @@ Note from Beckhoff: "A maximum of 1 MB persistent data can be reliably saved ove
 IF bRestoreOnStartup AND eGlobalSUpsState = eSUPS_PowerOK THEN
     bRestoreOnStartup := FALSE;
     bRestoreExecute := TRUE;
-    timeAsDTAtStartup := FILETIME64_TO_DT(F_GetSystemTime());
+    dtAtStartup := FILETIME64_TO_DT(F_GetSystemTime());
     iCurrentAxis := 1;
 
 END_IF
@@ -378,7 +378,7 @@ END_IF
 END_FOR
 
 //Store date and time at shutdown
-GVL.timeAtShutdownPersistent := FILETIME64_TO_DT(F_GetSystemTime());
+GVL.dtAtShutdownPersistent := FILETIME64_TO_DT(F_GetSystemTime());
 ]]></ST>
       </Implementation>
     </Action>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -196,7 +196,7 @@ END_IF
 //and should remain TRUE for the rest of the time the PLC is operational. Thus, this routine should only be completed once.
 IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
-    IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eDontRestore THEN
+    IF NOT GVL.astAxes[iCurrentAxis].stConfig.bRestorePosition THEN
         GVL.astAxes[iCurrentAxis].stStatus.bAxisHasBeenRestored := FALSE;
         eRestorePositions := eNextAxis;
     END_IF

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -21,13 +21,14 @@ VAR
     bExecuteReadEncRefSys: BOOL := FALSE;
     nRetry: INT; //A counter for startup actions
     iAxes: UINT; //Index for, for-loops in position recovery actions
-
     iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
-    afbReadEncRefSys: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
-    afbSetHomePosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_Home;
-    afbSetPosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_SetPosition;
+
     afbReadPositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
-    afbWritePositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_WriteParameter;
+    fbReadEncRefSys: MC_ReadParameter;
+    fbSetHomePosition: MC_Home;
+    fbSetPosition: MC_SetPosition;
+    fbWritePositionBias: MC_WriteParameter;
+
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
     timeAsDTAtStartup: DT;
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
@@ -203,33 +204,31 @@ END_IF
 //and should stay TRUE for the rest of the time the PLC is operational, thus this routine should only be completed once.
 IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
-        FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-            afbReadEncRefSys[iAxes](
-                Axis := GVL.astAxes[iAxes].Axis,
-                ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
-                ReadMode := E_READMODE.READMODE_ONCE);
+    fbReadEncRefSys(
+        Axis := GVL.astAxes[iCurrentAxis].Axis,
+        ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
+        ReadMode := E_READMODE.READMODE_ONCE);
+    //Position recovery for incremental encoders
+    IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestorePosition THEN
+        IF GVL.astAxesPersistent[iCurrentAxis].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+            fbSetHomePosition(
+                Axis := GVL.astAxes[iCurrentAxis].Axis,
+                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown,
+                HomingMode := MC_HomingMode.MC_Direct);
+        ELSE
+            fbSetPosition(
+                Axis := GVL.astAxes[iCurrentAxis].Axis,
+                Position := astAxesPersistent[iCurrentAxis].fPositionAtShutdown);
+        END_IF
+    END_IF
 
-            //Position recovery for incremental encoders
-            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestorePosition THEN
-                IF GVL.astAxesPersistent[iAxes].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iAxes].bMovingAtShutdown THEN
-                    afbSetHomePosition[iAxes](
-                        Axis := GVL.astAxes[iAxes].Axis,
-                        Position := astAxesPersistent[iAxes].fPositionAtShutdown,
-                        HomingMode := MC_HomingMode.MC_Direct);
-                ELSE
-                    afbSetPosition[iAxes](
-                        Axis := GVL.astAxes[iAxes].Axis,
-                        Position := astAxesPersistent[iAxes].fPositionAtShutdown);
-                END_IF
-            END_IF
-            //Position recovery for absolute encoders
-            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestorePositionBias THEN
-            afbWritePositionBias[iAxes](
-                Axis := GVL.astAxes[iAxes].Axis,
-                ParameterNumber := E_AxisParameters.AxisEncoderOffset,
-                Value := astAxesPersistent[iAxes].fEncoderBiasAtShutdown);
-            END_IF
-        END_FOR
+    //Position recovery for absolute encoders
+    IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestorePositionBias THEN
+        fbWritePositionBias(
+            Axis := GVL.astAxes[iCurrentAxis].Axis,
+            ParameterNumber := E_AxisParameters.AxisEncoderOffset,
+            Value := astAxesPersistent[iCurrentAxis].fEncoderBiasAtShutdown);
+    END_IF
 
 
     CASE eStartUp OF
@@ -309,16 +308,16 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                             END_IF
 
                             IF GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
-                                IF NOT afbSetPosition[iCurrentAxis].Done THEN
-                                    afbSetPosition[iCurrentAxis].Execute := FALSE;
+                                IF NOT fbSetPosition.Done THEN
+                                    fbSetPosition.Execute := FALSE;
                                     eStartUp := eExecuteRestore;
                                     RETURN;
                                 END_IF
                             END_IF
 
-                            IF GVL.astAxesPersistent[iAxes].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iAxes].bMovingAtShutdown THEN
-                                IF NOT afbSetHomePosition[iCurrentAxis].Done THEN
-                                    afbSetHomePosition[iCurrentAxis].Execute := FALSE;
+                            IF GVL.astAxesPersistent[iCurrentAxis].bHomedAtShutdown AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
+                                IF NOT fbSetHomePosition.Done THEN
+                                    fbSetHomePosition.Execute := FALSE;
                                     eStartUp := eExecuteRestore;
                                     RETURN;
                                 END_IF
@@ -333,8 +332,10 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                     END_CASE
             END_IF
 
-            afbSetHomePosition[iCurrentAxis].Execute := FALSE;
-            afbWritePositionBias[iCurrentAxis].Execute := FALSE;
+            fbSetHomePosition.Execute := FALSE;
+            fbSetPosition.Execute := FALSE;
+            fbWritePositionBias.Execute := FALSE;
+            fbReadEncRefSys.Enable := FALSE;
             eStartUp := eNextAxis;
 
         eNextAxis:

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -25,7 +25,10 @@ VAR
     afbReadPositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbWritePositionBias: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_WriteParameter;
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
-
+	fbSystemTime : GETSYSTEMTIME;
+    timeAsFileTime : T_FILETIME;
+    timeAsDT : DT;
+	timeAsDTAtStartup : DT;
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
 END_VAR
 

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -19,8 +19,9 @@ VAR
     bPositionRestoreDone: BOOL := FALSE;
     bRestoreExecute: BOOL := FALSE;
     bExecuteReadEncRefSys: BOOL := FALSE;
-    nRetry: INT; //Counter for startup actions
-    iAxes: UINT := 1; //Index for, for loops in position recovery actions
+    nRetry: INT; //A counter for startup actions
+    iAxes: UINT; //Index for, for-loops in position recovery actions
+
     iCurrentAxis: UINT := 1; //Index for position recovery actions (not in for loops)
     afbReadEncRefSys: ARRAY [1..GVL_APP.nAXIS_NUM] OF MC_ReadParameter;
     afbSetHomePosition: ARRAY[1..GVL_APP.nAXIS_NUM] OF MC_Home;
@@ -210,19 +211,13 @@ END_IF
 //and should stay TRUE for the rest of the time the PLC is operational, thus this routine should only be completed once.
 IF bRestoreExecute AND NOT bPositionRestoreDone THEN
 
-//  //If current axis has not been initialized properly or was not homed before power failure, perform position recovery for next axis
-//    IF NOT astAxes[iCurrentAxis].stStatus.bAxisInitialized OR NOT astAxesPersistent[iCurrentAxis].bHomedAtShutdown THEN
-//        eStartUp := eNextAxis;
-//    ELSE
-        //Cycle through function blocks that read the encoder reference system i.e. whether axis is incremental or absolute
-        //Cycle through set position and MC_WritePArameter function blocks for each axis
         FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
             afbReadEncRefSys[iAxes](
                 Axis := GVL.astAxes[iAxes].Axis,
                 ParameterNumber := MC_AxisParameter.AxisEncoderReferenceSystem,
                 ReadMode := E_READMODE.READMODE_ONCE);
 
-            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+            IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR NOT GVL.astAxesPersistent[iAxes].bHomedAtShutdown THEN
                 afbSetPosition[iAxes](
                     Axis := GVL.astAxes[iAxes].Axis,
                     Position := astAxesPersistent[iAxes].fPositionAtShutdown);
@@ -238,7 +233,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                 ParameterNumber := E_AxisParameters.AxisEncoderOffset,
                 Value := astAxesPersistent[iAxes].fEncoderBiasAtShutdown);
         END_FOR
-//    END_IF
+
 
     CASE eStartUp OF
         eColdStart:
@@ -249,7 +244,11 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             END_IF
 
         eReadAxisFeedbackType:
-            //Exectute the function blocks to read the encoder reference system (0=inc OR 1=ABS)
+            IF NOT GVL.astAxesPersistent[iCurrentAxis].bInitialized THEN
+                eStartUp := eNextAxis;
+                RETURN;
+            END_IF
+            //Execute the function blocks to read the encoder reference system (0=inc OR 1=ABS)
             afbReadEncRefSys[iCurrentAxis].Enable := TRUE;
             eStartUp := eCheckReadDone;
 
@@ -278,11 +277,10 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
         eExecuteRestore:
             //Execute position and encoder BIAS restore by setting Execute = TRUE
             IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-                IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
                     CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
                         INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
                             // Restore position value for incremental encoders
-                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
                                 afbSetPosition[iCurrentAxis].Execute := TRUE;
                             ELSIF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
                                 afbSetHomePosition[iCurrentAxis].Execute := TRUE;
@@ -291,9 +289,6 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                             // Restore encoder position BIAS for absolute encoders
                             afbWritePositionBias[iCurrentAxis].Execute := TRUE;
                     END_CASE
-                ELSE
-                    RETURN;
-                END_IF
             END_IF
 
             eStartUp := eCheckRestore;
@@ -303,7 +298,6 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
             //bPositionRestoreDone will never get set to TRUE and will take up cycle time
             IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition <> E_RestorePosition.eDontRestore THEN
-                IF NOT astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
                     CASE LREAL_TO_UINT(afbReadEncRefSys[iCurrentAxis].Value) OF
                         INCREMENTAL, ABSOLUTE_MODULO, INCREMENTAL_SINGLETURN_ABSOLUTE:
                             IF afbSetPosition[iCurrentAxis].Busy THEN
@@ -316,7 +310,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                                 RETURN;
                             END_IF
 
-                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
                                 IF NOT afbSetPosition[iCurrentAxis].Done THEN
                                     afbSetPosition[iCurrentAxis].Execute := FALSE;
                                     eStartUp := eExecuteRestore;
@@ -324,7 +318,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                                 END_IF
                             END_IF
 
-                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+                            IF GVL.astAxes[iCurrentAxis].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome AND NOT GVL.astAxesPersistent[iCurrentAxis].bMovingAtShutdown THEN
                                 IF NOT afbSetHomePosition[iCurrentAxis].Done THEN
                                     afbSetHomePosition[iCurrentAxis].Execute := FALSE;
                                     eStartUp := eExecuteRestore;
@@ -339,9 +333,6 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                                 RETURN;
                             END_IF
                     END_CASE
-                END_IF
-            //ELSE
-                //RETURN;
             END_IF
 
             afbSetHomePosition[iCurrentAxis].Execute := FALSE;

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -10,11 +10,11 @@ VAR
     hmiAxisSelection: INT := 1; //Specifies the currently selected axis for HMI operations, allowing the user to control a specific axis
     hmiPneumaticAxisSelection: INT := 1; //Specifies the currently selected pneumatic axis for HMI operation, allowing the user to control the specific axis
 
-//Startup, Shutdown and UPS
+	//Startup, Shutdown and UPS
     fbCX5130UPS: FB_S_UPS_CX51x0;
     fbC6017UPS: FB_S_UPS_BAPI;
     eSelUpsMode: E_S_UPS_Mode := eSUPS_WrPersistData_Shutdown; //Selected UPS mode
-    eStartUp: (eColdStart, eReadAxisFeedbackType, eCheckReadDone, eExecuteRestore, eCheckRestore, eFinishRestore);
+    eStartUp: (eColdStart, eReadAxisFeedbackType, eCheckReadDone, eExecuteRestore, eCheckRestore, eNextAxis, eRestoreFinished);
     bPositionRestoreDone: BOOL := FALSE;
     bRestoreExecute: BOOL := FALSE;
     bExecuteReadEncRefSys: BOOL := FALSE;
@@ -291,17 +291,26 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                 ELSE
                     RETURN;
                 END_IF
-            END_FOR
-            eStartUp :=  eFinishRestore;
-
-        eFinishRestore:
-            //Remove execute = TRUE for afbRestorePosition and fbWritePositionBias
-            FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                afbSetHomePosition[iAxes].Execute := FALSE;
-                afbWritePositionBias[iAxes].Execute := FALSE;
-                bPositionRestoreDone := TRUE;
-                bRestoreExecute := FALSE;
-            END_FOR
+			//ELSE
+				//RETURN;
+			END_IF
+          
+			afbSetHomePosition[iCurrentAxis].Execute := FALSE;
+            afbWritePositionBias[iCurrentAxis].Execute := FALSE;
+            eStartUp := eNextAxis;
+		
+		eNextAxis:
+			iCurrentAxis := iCurrentAxis + 1;
+			IF iCurrentAxis > GVL_APP.nAXIS_NUM THEN
+				eStartUp := eRestoreFinished;
+				bPositionRestoreDone := TRUE;
+				bRestoreExecute := FALSE;
+			ELSE 
+				eStartUp := eReadAxisFeedbackType;
+			END_IF
+			
+        eRestoreFinished:
+			//Do nothing
     END_CASE
 END_IF
 ]]></ST>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -225,7 +225,7 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
                 IF NOT afbReadEncRefSys[iAxes].Valid THEN
                     IF afbReadEncRefSys[iAxes].Busy THEN
-                        //Exit MAIN.STARTUP Action and wait till next cycle, needs to cycle through whole program in order for data to update
+                        //Exit MAIN.RESTORE_POSITIONS Action and wait till next cycle, needs to cycle through whole program in order for data to update
                         RETURN;
                     ELSE
                         //Sometimes the code gets here and the afbReadEncRefSys[iAxes] misses the rising edge. If  the code gets here it means
@@ -244,7 +244,8 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
         eExecuteRestore:
             //Execute position and encoder BIAS restore by setting Execute = TRUE
            FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR 
+					GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
                     //Restore position value for incremental encoders
                     IF NOT astAxesPersistent[iAxes].bMovingAtShutdown AND
                     (afbReadEncRefSys[iAxes].Value = 0 OR
@@ -269,7 +270,8 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             //Nothing actually happens if the restore is not done, the code just returns from here each cycle and the
             //bPositionRestoreDone will never get set to TRUE and will take up cycle time
             FOR iAxes := 1 TO GVL_APP.nAXIS_NUM DO
-                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome THEN
+                IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithoutHome OR  
+					GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
                     IF NOT astAxesPersistent[iAxes].bMovingAtShutdown AND
                     (afbReadEncRefSys[iAxes].Value = 0 OR
                      afbReadEncRefSys[iAxes].Value = 2 OR
@@ -301,6 +303,11 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
                 afbWritePositionBias[iAxes].Execute := FALSE;
                 bPositionRestoreDone := TRUE;
                 bRestoreExecute := FALSE;
+				IF GVL.astAxes[iAxes].stConfig.eRestorePosition = E_RestorePosition.eRestoreWithHome THEN
+					GVL.astAxes[iAxes].stControl.bEnable := TRUE;
+					GVL.astAxes[iAxes].stControl.eCommand := E_MotionFunctions.eHome;
+					GVL.astAxes[iAxes].stControl.bExecute := TRUE;
+				END_IF
             END_FOR
     END_CASE
 END_IF


### PR DESCRIPTION
1. Check that position, encoder position bias are saved after a power failure.  
2. Check that we timestamp the power failure and startup of the CPU. 
3. At startup check that axises are calibrated and initliazed correctly. 