### PR TITLE
MBP-388: Safety Implementation for ESTIA

### DIFF
--- a/solution/_Config/IO/Device 1 (EtherCAT).xti
+++ b/solution/_Config/IO/Device 1 (EtherCAT).xti
@@ -1,0 +1,1718 @@
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.62" ClassName="CDevEtherCATDef" SubType="111">
+	<DataTypes>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000008}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..0] OF BYTE</Name>
+			<BitSize>8</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>1</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000004}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..3] OF BIT</Name>
+			<BitSize>4</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>4</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000006}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..5] OF BIT</Name>
+			<BitSize>6</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>6</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000010}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..1] OF BYTE</Name>
+			<BitSize>16</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>2</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000002}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..1] OF BIT</Name>
+			<BitSize>2</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>2</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000001}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..0] OF BIT</Name>
+			<BitSize>1</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>1</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000003}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..2] OF BIT</Name>
+			<BitSize>3</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>3</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000009}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..8] OF BIT</Name>
+			<BitSize>9</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>9</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-00200000000C}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..11] OF BIT</Name>
+			<BitSize>12</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>12</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-00200000000E}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..13] OF BIT</Name>
+			<BitSize>14</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>14</Elements>
+			</ArrayInfo>
+		</DataType>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-00200000000D}" IecBaseType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..12] OF BIT</Name>
+			<BitSize>13</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>13</Elements>
+			</ArrayInfo>
+		</DataType>
+	</DataTypes>
+	<ImageDatas>
+		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ff808080808080808080808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff0000c00000c0ffffffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
+		<ImageData Id="1001">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000120b0000120b00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff0000ff0000ff0000ff0000ff0000ff0000ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff0000ff0000ff0000ff0000ff0000ff0000ffc0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff0000ff0000ff0000ff0000ff0000ff0000ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff0000ff0000ff0000ff0000ff0000ff0000ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff0000ff0000ff0000ff0000ff0000ff0000ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff0000ff0000ff0000ff0000ff0000ff0000ffc0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff0000ff0000ff0000ff0000ff0000ff0000ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
+		<ImageData Id="1002">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000000000ff00ffff00ffff00ff000000ff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ff000000ff00ffff00ffff00ff000000ff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff000000ff00ffff00ffff00ff000000ff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ff000000ff00ff000000ff00ff000000ff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff000000000000ff00ff000000000000ff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff000000ff00ffff00ffff00ff000000ff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
+		<ImageData Id="1003">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
+		<ImageData Id="1004">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ff808080808080808080808080808080808080808080808080808080808080808080808080ff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0000000c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffc0c0c0c0c0c0000000000000000000000000000000000000000000c0c0c0c0c0c0808080007fff007fff007fff007fffc0c0c0c0c0c00000000000000000000000000000000000000000000000ffc0c0c0808080007fff007fff007fff007fffc0c0c0c0c0c0000000000000000000000000000000000000000000c0c0c0c0c0c0808080007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0000000c0c0c0c0c0c0000000c0c0c0c0c0c0808080007fff007fff007fff007fffc0c0c0c0c0c0000000000000000000000000c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080007fff007fff007fff007fffc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0808080</ImageData>
+		<ImageData Id="1005">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff007fff007fff007fff007fff007fff007fffc0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ff</ImageData>
+	</ImageDatas>
+	<Device Id="1" DevType="111" DevFlags="#x0003" AmsPort="28673" AmsNetId="172.30.41.145.2.1" RemoteName="Device 1 (EtherCAT)" InfoImageId="3">
+		<Name>__FILENAME__</Name>
+		<AddressInfo>
+			<Ccat>
+				<Address>-801112064</Address>
+				<Offset>131072</Offset>
+				<Size>8192</Size>
+				<BaseAddr>0</BaseAddr>
+				<BusNo>3</BusNo>
+				<SlotNo>0</SlotNo>
+				<VendorId>5612</VendorId>
+				<DeviceId>20480</DeviceId>
+				<Dma>
+					<Address>0</Address>
+					<Offset>4096</Offset>
+					<Size>256</Size>
+					<BaseAddr>2</BaseAddr>
+					<RxChn>0</RxChn>
+					<TxChn>1</TxChn>
+				</Dma>
+				<Identification>
+					<Value>498694182</Value>
+					<Version>1</Version>
+					<Size>256</Size>
+				</Identification>
+			</Ccat>
+		</AddressInfo>
+		<Image Id="2" AddrType="9" ImageType="3">
+			<Name>Image</Name>
+		</Image>
+		<Box Id="1" BoxType="9099">
+			<Name>Term 1 (EK1200)</Name>
+			<ImageId>1000</ImageId>
+			<EtherCAT PdiType="#x0100" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x04b02c52" RevisionNo="#x00001388" InfoDataState="false" PortPhys="49" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EK1200-5000 EtherCAT Power supply (2A E-Bus)" Desc="EK1200" PortABoxInfo="#x00ffffff"/>
+			<Box Id="2" BoxType="9099">
+				<Name>Term 2 (EL1018)</Name>
+				<ImageId>7</ImageId>
+				<EtherCAT SlaveType="1" PdiType="#x0104" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x03fa3052" RevisionNo="#x00120000" RepeatSupport="true" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL1018 8Ch. Dig. Input 24V, 10µs" Desc="EL1018" PortABoxInfo="#x01000001">
+					<SyncMan>001001000000010004000000000000000100001000010000</SyncMan>
+					<Fmmu>0000000000000000001000010100000002000000000000000000000000000000</Fmmu>
+					<Pdo Name="Channel 1" Index="#x1a00" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 2" Index="#x1a01" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 3" Index="#x1a02" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 4" Index="#x1a03" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6030" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 5" Index="#x1a04" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6040" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 6" Index="#x1a05" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6050" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 7" Index="#x1a06" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6060" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 8" Index="#x1a07" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6070" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+				</EtherCAT>
+			</Box>
+			<Box Id="3" BoxType="9099">
+				<Name>Term 3 (EL2808)</Name>
+				<ImageId>1001</ImageId>
+				<EtherCAT SlaveType="1" PdiType="#x0104" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x0af83052" RevisionNo="#x00110000" RepeatSupport="true" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL2808 8Ch. Dig. Output 24V, 0.5A" Desc="EL2808" PortABoxInfo="#x01000002">
+					<SyncMan>000f01004400010003000000010001000100000f44090000</SyncMan>
+					<Fmmu>0000000000000000000f00020100000001000000000000000000000000000000</Fmmu>
+					<Pdo Name="Channel 1" Index="#x1600" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 2" Index="#x1601" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 3" Index="#x1602" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 4" Index="#x1603" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7030" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 5" Index="#x1604" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7040" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 6" Index="#x1605" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7050" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 7" Index="#x1606" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7060" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 8" Index="#x1607" InOut="1" Flags="#x0011" SyncMan="0">
+						<Entry Name="Output" Index="#x7070" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+				</EtherCAT>
+			</Box>
+			<Box Id="4" BoxType="9099" BoxFlags="#x00000020">
+				<Name>Term 4 (EL5101)</Name>
+				<ImageId>1002</ImageId>
+				<EtherCAT SlaveType="2" PdiType="#x0c05" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="7" FoeType="1" VendorId="#x00000002" ProductCode="#x13ed3052" RevisionNo="#x04000000" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL5101 1Ch. Inc. Encoder 5V" Desc="EL5101" PortABoxInfo="#x01000003">
+					<SyncMan>001830002600010001000000300030003000001826010000</SyncMan>
+					<SyncMan>801830002200010002000000300030003000801822010000</SyncMan>
+					<SyncMan>001004002400010003000000000000000300001024010000</SyncMan>
+					<SyncMan>001106002000010004000000000000000500001120010000</SyncMan>
+					<Fmmu>0000000000000000001000020100000001000000000000000000000000000000</Fmmu>
+					<Fmmu>0000000000000000001100010100000002000000000000000000000000000000</Fmmu>
+					<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
+					<BootStrapData>0010f400f410f400</BootStrapData>
+					<DcMode>53796e6368726f6e00000000000000004672656552756e2f534d2d53796e6368726f6e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<DcMode>4443000000000000000000000000000044432d53796e6368726f6e000000000000000000000000000000000000000000000000000000000000000000000020030100000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<DcMode>4443494e00000000000000000000000044432d53796e6368726f6e2028696e7075742062617365642900000000000000000000000000000000000000000020030100000000000000000001000000000000000000000000000000000000000000</DcMode>
+					<Pdo Name="Inputs" Index="#x1a00" Flags="#x0010">
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<ExcludePdo>#x1a03</ExcludePdo>
+						<ExcludePdo>#x1a04</ExcludePdo>
+						<ExcludePdo>#x1a05</ExcludePdo>
+						<ExcludePdo>#x1a06</ExcludePdo>
+						<ExcludePdo>#x1a07</ExcludePdo>
+						<ExcludePdo>#x1a08</ExcludePdo>
+						<Entry Name="Status" Index="#x6000" Sub="#x01">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry Name="Value" Index="#x6000" Sub="#x02">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Latch" Index="#x6000" Sub="#x03">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Inputs" Index="#x1a01" Flags="#x0010">
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<ExcludePdo>#x1a03</ExcludePdo>
+						<ExcludePdo>#x1a04</ExcludePdo>
+						<ExcludePdo>#x1a05</ExcludePdo>
+						<ExcludePdo>#x1a06</ExcludePdo>
+						<ExcludePdo>#x1a07</ExcludePdo>
+						<ExcludePdo>#x1a08</ExcludePdo>
+						<Entry Name="Status" Index="#x6000" Sub="#x01">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry>
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="Value" Index="#x6000" Sub="#x02">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Latch" Index="#x6000" Sub="#x03">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Inputs" Index="#x1a02" Flags="#x0010">
+						<ExcludePdo>#x1a03</ExcludePdo>
+						<ExcludePdo>#x1a04</ExcludePdo>
+						<ExcludePdo>#x1a05</ExcludePdo>
+						<ExcludePdo>#x1a06</ExcludePdo>
+						<ExcludePdo>#x1a07</ExcludePdo>
+						<ExcludePdo>#x1a08</ExcludePdo>
+						<Entry Name="Frequency" Index="#x6000" Sub="#x04">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Period" Index="#x6000" Sub="#x05">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Window" Index="#x6000" Sub="#x06">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Status compact" Index="#x1a03" Flags="#x0010" SyncMan="3">
+						<ExcludePdo>#x1a04</ExcludePdo>
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<ExcludePdo>#x1a02</ExcludePdo>
+						<Entry Name="Status__Latch C valid" Index="#x6010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Latch extern valid" Index="#x6010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Set counter done" Index="#x6010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter underflow" Index="#x6010" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter overflow" Index="#x6010" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input status" Index="#x6010" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Open circuit" Index="#x6010" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Extrapolation stall" Index="#x6010" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input A" Index="#x6010" Sub="#x09">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input B" Index="#x6010" Sub="#x0a">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input C" Index="#x6010" Sub="#x0b">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input gate" Index="#x6010" Sub="#x0c">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of extern latch" Index="#x6010" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6010" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO State" Index="#x6010" Sub="#x0f">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6010" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Counter value" Index="#x6010" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Latch value" Index="#x6010" Sub="#x12">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Status" Index="#x1a04" Flags="#x0010">
+						<ExcludePdo>#x1a03</ExcludePdo>
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<ExcludePdo>#x1a02</ExcludePdo>
+						<Entry Name="Status__Latch C valid" Index="#x6010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Latch extern valid" Index="#x6010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Set counter done" Index="#x6010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter underflow" Index="#x6010" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter overflow" Index="#x6010" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input status" Index="#x6010" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Open circuit" Index="#x6010" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Extrapolation stall" Index="#x6010" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input A" Index="#x6010" Sub="#x09">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input B" Index="#x6010" Sub="#x0a">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input C" Index="#x6010" Sub="#x0b">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input gate" Index="#x6010" Sub="#x0c">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of extern latch" Index="#x6010" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6010" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO State" Index="#x6010" Sub="#x0f">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6010" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Counter value" Index="#x6010" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Latch value" Index="#x6010" Sub="#x12">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Frequency" Index="#x1a05" Flags="#x0010">
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<ExcludePdo>#x1a02</ExcludePdo>
+						<ExcludePdo>#x1a06</ExcludePdo>
+						<Entry Name="Frequency value" Index="#x6010" Sub="#x13">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Period" Index="#x1a06" Flags="#x0010">
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<ExcludePdo>#x1a02</ExcludePdo>
+						<ExcludePdo>#x1a05</ExcludePdo>
+						<Entry Name="Period value" Index="#x6010" Sub="#x14">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Timest." Index="#x1a07" Flags="#x0010">
+						<ExcludePdo>#x1a08</ExcludePdo>
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<ExcludePdo>#x1a02</ExcludePdo>
+						<Entry Name="Timestamp" Index="#x6010" Sub="#x16">
+							<Type>ULINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Timest. compact" Index="#x1a08" Flags="#x0010">
+						<ExcludePdo>#x1a07</ExcludePdo>
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<ExcludePdo>#x1a02</ExcludePdo>
+						<Entry Name="Timestamp" Index="#x6010" Sub="#x16">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Outputs" Index="#x1600" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1601</ExcludePdo>
+						<ExcludePdo>#x1602</ExcludePdo>
+						<ExcludePdo>#x1603</ExcludePdo>
+						<Entry Name="Ctrl" Index="#x7000" Sub="#x01">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry Name="Value" Index="#x7000" Sub="#x02">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Outputs" Index="#x1601" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1600</ExcludePdo>
+						<ExcludePdo>#x1602</ExcludePdo>
+						<ExcludePdo>#x1603</ExcludePdo>
+						<Entry Name="Ctrl" Index="#x7000" Sub="#x01">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry>
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="Value" Index="#x7000" Sub="#x02">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Control compact" Index="#x1602" InOut="1" Flags="#x0010" SyncMan="2">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1600</ExcludePdo>
+						<ExcludePdo>#x1601</ExcludePdo>
+						<Entry Name="Control__Enable latch C" Index="#x7010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on positive edge" Index="#x7010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Set counter" Index="#x7010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on negative edge" Index="#x7010" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000004}">ARRAY [0..3] OF BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="Set counter value" Index="#x7010" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Control" Index="#x1603" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1602</ExcludePdo>
+						<ExcludePdo>#x1600</ExcludePdo>
+						<ExcludePdo>#x1601</ExcludePdo>
+						<Entry Name="Control__Enable latch C" Index="#x7010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on positive edge" Index="#x7010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Set counter" Index="#x7010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on negative edge" Index="#x7010" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000004}">ARRAY [0..3] OF BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="Set counter value" Index="#x7010" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<CoeProfile ProfileNo="33428361" DisplayName="MDP 510"/>
+					<CoeProfile ProfileNo="33493897" DisplayName="MDP 511"/>
+				</EtherCAT>
+			</Box>
+			<Box Id="5" BoxType="9099">
+				<Name>Term 5 (EL9505)</Name>
+				<ImageId>1003</ImageId>
+				<EtherCAT SlaveType="1" PdiType="#x0104" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x25213052" RevisionNo="#x00110000" RepeatSupport="true" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL9505 Power supply terminal 5V" Desc="EL9505" PortABoxInfo="#x01000004">
+					<SyncMan>001001000000010004000000000000000000001000000000</SyncMan>
+					<Fmmu>0000000000000000001000010100000002000000000000000000000000000000</Fmmu>
+					<Pdo Name="Status Uo" Index="#x1a00" Flags="#x0011" SyncMan="0">
+						<Entry Name="Power OK" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Overload" Index="#x6000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+				</EtherCAT>
+			</Box>
+			<Box Id="6" BoxType="9099">
+				<Name>Term 6 (EL1252-0050)</Name>
+				<ImageId>7</ImageId>
+				<EtherCAT SlaveType="1" PdiType="#x0104" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x04e43052" RevisionNo="#x00110032" InfoDataDcTimes="true" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL1252-0050 2Ch. Fast Dig. Input 5V, 1µs, DC Latch" Desc="EL1252-0050" PortABoxInfo="#x01000005">
+					<SyncMan>001001002000010004000000000000000100001022010000</SyncMan>
+					<SyncMan>ae0922000000000004000000000000000000ae0900040000</SyncMan>
+					<SyncMan>100900000000000004000000000000000000100900040000</SyncMan>
+					<Fmmu>0000000000000000001000010100000002000000060000000000000000000000</Fmmu>
+					<Fmmu>0000000000000000ae0900010100000002000000060000000100000000000000</Fmmu>
+					<Fmmu>0000000000000000100900010000000002000000060000000200000000000000</Fmmu>
+					<DcData>0001000000000000000000000000000000000000000000000000000000000000</DcData>
+					<DcMode>44634c617463680000000000000000004443204c617463682053657474696e6773000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<Pdo Name="Channel 1" Index="#x1a00" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 2" Index="#x1a01" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry>
+							<Type GUID="{18071995-0000-0000-0000-002000000006}">ARRAY [0..5] OF BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Reserved" Index="#x1a02" Flags="#x0011" SyncMan="0"/>
+					<Pdo Name="Latch" Index="#x1a10" Flags="#x0030">
+						<ExcludePdo>#x1a11</ExcludePdo>
+						<ExcludePdo>#x1a12</ExcludePdo>
+						<ExcludePdo>#x1a13</ExcludePdo>
+						<ExcludePdo>#x1a16</ExcludePdo>
+						<Entry Name="Status1" Index="#x1d09" Sub="#xae">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry Name="Status2" Index="#x1d09" Sub="#xaf">
+							<Type>USINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Latch" Index="#x1a11" Flags="#x0030">
+						<ExcludePdo>#x1a10</ExcludePdo>
+						<ExcludePdo>#x1a12</ExcludePdo>
+						<ExcludePdo>#x1a13</ExcludePdo>
+						<ExcludePdo>#x1a16</ExcludePdo>
+						<Entry Name="Status1" Index="#x1d09" Sub="#xae">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry>
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="LatchPos2" Index="#x1d09" Sub="#xb0">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Latch" Index="#x1a12" Flags="#x0030">
+						<ExcludePdo>#x1a10</ExcludePdo>
+						<ExcludePdo>#x1a11</ExcludePdo>
+						<ExcludePdo>#x1a13</ExcludePdo>
+						<ExcludePdo>#x1a16</ExcludePdo>
+						<Entry Name="Status1" Index="#x1d09" Sub="#xae">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry>
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="LatchPos1" Index="#x1d09" Sub="#xb0">
+							<Type>ULINT</Type>
+						</Entry>
+						<Entry Name="LatchNeg1" Index="#x1d09" Sub="#xb8">
+							<Type>ULINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Latch" Index="#x1a13" Flags="#x0030" SyncMan="1">
+						<ExcludePdo>#x1a10</ExcludePdo>
+						<ExcludePdo>#x1a11</ExcludePdo>
+						<ExcludePdo>#x1a12</ExcludePdo>
+						<ExcludePdo>#x1a16</ExcludePdo>
+						<Entry Name="Status1" Index="#x1d09" Sub="#xae">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry Name="Status2" Index="#x1d09" Sub="#xaf">
+							<Type>USINT</Type>
+						</Entry>
+						<Entry Name="LatchPos1" Index="#x1d09" Sub="#xb0">
+							<Type>ULINT</Type>
+						</Entry>
+						<Entry Name="LatchNeg1" Index="#x1d09" Sub="#xb8">
+							<Type>ULINT</Type>
+						</Entry>
+						<Entry Name="LatchPos2" Index="#x1d09" Sub="#xc0">
+							<Type>ULINT</Type>
+						</Entry>
+						<Entry Name="LatchNeg2" Index="#x1d09" Sub="#xc8">
+							<Type>ULINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="SysTime" Index="#x1a14" Flags="#x0030">
+						<ExcludePdo>#x1a15</ExcludePdo>
+						<Entry Name="SysTime" Index="#x1d09" Sub="#x10">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="SysTime" Index="#x1a15" Flags="#x0030">
+						<ExcludePdo>#x1a14</ExcludePdo>
+						<Entry Name="SysTime" Index="#x1d09" Sub="#x10">
+							<Type>ULINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Latch" Index="#x1a16" Flags="#x0030">
+						<ExcludePdo>#x1a10</ExcludePdo>
+						<ExcludePdo>#x1a11</ExcludePdo>
+						<ExcludePdo>#x1a12</ExcludePdo>
+						<ExcludePdo>#x1a13</ExcludePdo>
+						<Entry>
+							<Type GUID="{18071995-0000-0000-0000-002000000010}">ARRAY [0..1] OF BYTE</Type>
+						</Entry>
+						<Entry Name="LatchPos1" Index="#x6000" Sub="#x11">
+							<Type>ULINT</Type>
+						</Entry>
+						<Entry Name="LatchNeg1" Index="#x6000" Sub="#x13">
+							<Type>ULINT</Type>
+						</Entry>
+						<Entry Name="LatchPos2" Index="#x6010" Sub="#x11">
+							<Type>ULINT</Type>
+						</Entry>
+						<Entry Name="LatchNeg2" Index="#x6010" Sub="#x13">
+							<Type>ULINT</Type>
+						</Entry>
+					</Pdo>
+					<CoeProfile ProfileNo="8197001"/>
+					<CoeProfile ProfileNo="8197001"/>
+				</EtherCAT>
+			</Box>
+			<Box Id="7" BoxType="9099">
+				<Name>Term 7 (EL9410)</Name>
+				<ImageId>1003</ImageId>
+				<EtherCAT SlaveType="1" PdiType="#x0104" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x24c23052" RevisionNo="#x00110000" RepeatSupport="true" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL9410 E-Bus Power Supplier  (Diagnostics)" Desc="EL9410" PortABoxInfo="#x01000006">
+					<SyncMan>001001000000010004000000000000000000001000000000</SyncMan>
+					<Fmmu>0000000000000000001000010100000002000000000000000000000000000000</Fmmu>
+					<Pdo Name="Status Us" Index="#x1a00" Flags="#x0011" SyncMan="0">
+						<Entry Name="Undervoltage" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Status Up" Index="#x1a01" Flags="#x0011" SyncMan="0">
+						<Entry Name="Undervoltage" Index="#x6010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+				</EtherCAT>
+			</Box>
+			<Box Id="8" BoxType="9099" BoxFlags="#x00000020">
+				<Name>Term 8 (EL7037)</Name>
+				<ImageId>1004</ImageId>
+				<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b7d3052" RevisionNo="#x00110000" InfoDataAddr="true" InfoDataSoeDS401="true" RepeatSupport="true" SetFrameRepeatTime="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7037 1Ch. Stepper motor output stage (24V, 1.5A)" Desc="EL7037" PortABoxInfo="#x01000007">
+					<SyncMan>001080002600010001000000400080008000001026010000</SyncMan>
+					<SyncMan>801080002200010002000000400080008000801022010000</SyncMan>
+					<SyncMan>001108002400010003000000000000000800001124010000</SyncMan>
+					<SyncMan>801108002000010004000000000000000800801120010000</SyncMan>
+					<Fmmu>0000000000000000001100020100000001000000000000000000000000000000</Fmmu>
+					<Fmmu>0000000000000000801100010100000002000000000000000000000000000000</Fmmu>
+					<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
+					<BootStrapData>0010f400f410f400</BootStrapData>
+					<DcMode>53796e6368726f6e00000000000000004672656552756e2f534d2d53796e6368726f6e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<DcMode>4443000000000000000000000000000044432d53796e6368726f6e000000000000000000000000000000000000000000000000000000000000000000000000030100000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<MBoxUserCmdData>004003000c0000000000000003000000000000000000000000000000000000002081f001040000000000110000</MBoxUserCmdData>
+					<MBoxUserCmdData>004003000a00000000000000030010000000000000000000000000000000000020f3100502000000010000</MBoxUserCmdData>
+					<Pdo Name="ENC Status compact" Index="#x1a00" Flags="#x0010" SyncMan="3">
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<Entry Name="Status__Latch C valid" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Latch extern valid" Index="#x6000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Set counter done" Index="#x6000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter underflow" Index="#x6000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter overflow" Index="#x6000" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000002}">ARRAY [0..1] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Extrapolation stall" Index="#x6000" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input A" Index="#x6000" Sub="#x09">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input B" Index="#x6000" Sub="#x0a">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input C" Index="#x6000" Sub="#x0b">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of extern latch" Index="#x6000" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6000" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6000" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Counter value" Index="#x6000" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Latch value" Index="#x6000" Sub="#x12">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Status" Index="#x1a01" Flags="#x0010">
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<Entry Name="Status__Latch C valid" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Latch extern valid" Index="#x6000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Set counter done" Index="#x6000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter underflow" Index="#x6000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter overflow" Index="#x6000" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000002}">ARRAY [0..1] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Extrapolation stall" Index="#x6000" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input A" Index="#x6000" Sub="#x09">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input B" Index="#x6000" Sub="#x0a">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input C" Index="#x6000" Sub="#x0b">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of extern latch" Index="#x6000" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6000" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6000" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Counter value" Index="#x6000" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Latch value" Index="#x6000" Sub="#x12">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Timest. compact" Index="#x1a02" Flags="#x0010">
+						<Entry Name="Timestamp" Index="#x6000" Sub="#x16">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Status" Index="#x1a03" Flags="#x0010" SyncMan="3">
+						<Entry Name="Status__Ready to enable" Index="#x6010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Ready" Index="#x6010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Warning" Index="#x6010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Error" Index="#x6010" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Moving positive" Index="#x6010" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Moving negative" Index="#x6010" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Torque reduced" Index="#x6010" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Motor stall" Index="#x6010" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000003}">ARRAY [0..2] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Digital input 1" Index="#x6010" Sub="#x0c">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Digital input 2" Index="#x6010" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6010" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6010" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Synchron info data" Index="#x1a04" Flags="#x0010">
+						<Entry Name="Info data 1" Index="#x6010" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Info data 2" Index="#x6010" Sub="#x12">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Motor load" Index="#x1a05" Flags="#x0010">
+						<Entry Name="Motor load" Index="#x6010" Sub="#x13">
+							<Type>INT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Status compact" Index="#x1a06" Flags="#x0010">
+						<ExcludePdo>#x1a07</ExcludePdo>
+						<Entry Name="Status__Busy" Index="#x6020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__In-Target" Index="#x6020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Warning" Index="#x6020" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Error" Index="#x6020" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Calibrated" Index="#x6020" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Accelerate" Index="#x6020" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Decelerate" Index="#x6020" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000009}">ARRAY [0..8] OF BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Status" Index="#x1a07" Flags="#x0010">
+						<ExcludePdo>#x1a06</ExcludePdo>
+						<Entry Name="Status__Busy" Index="#x6020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__In-Target" Index="#x6020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Warning" Index="#x6020" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Error" Index="#x6020" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Calibrated" Index="#x6020" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Accelerate" Index="#x6020" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Decelerate" Index="#x6020" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000009}">ARRAY [0..8] OF BIT</Type>
+						</Entry>
+						<Entry Name="Actual position" Index="#x6020" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Actual velocity" Index="#x6020" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+						<Entry Name="Actual drive time" Index="#x6020" Sub="#x22">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Internal position" Index="#x1a08" Flags="#x0010">
+						<Entry Name="Internal position" Index="#x6010" Sub="#x14">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM External position" Index="#x1a09" Flags="#x0010">
+						<Entry Name="External position" Index="#x6010" Sub="#x15">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Control compact" Index="#x1600" InOut="1" Flags="#x0010" SyncMan="2">
+						<ExcludePdo>#x1601</ExcludePdo>
+						<Entry Name="Control__Enable latch C" Index="#x7000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on positive edge" Index="#x7000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Set counter" Index="#x7000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on negative edge" Index="#x7000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000C}">ARRAY [0..11] OF BIT</Type>
+						</Entry>
+						<Entry Name="Set counter value" Index="#x7000" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Control" Index="#x1601" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1600</ExcludePdo>
+						<Entry Name="Control__Enable latch C" Index="#x7000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on positive edge" Index="#x7000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Set counter" Index="#x7000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on negative edge" Index="#x7000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000C}">ARRAY [0..11] OF BIT</Type>
+						</Entry>
+						<Entry Name="Set counter value" Index="#x7000" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Control" Index="#x1602" InOut="1" Flags="#x0010" SyncMan="2">
+						<Entry Name="Control__Enable" Index="#x7010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Reset" Index="#x7010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Reduce torque" Index="#x7010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="Control__Digital output 1" Index="#x7010" Sub="#x0c">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000004}">ARRAY [0..3] OF BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Position" Index="#x1603" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<ExcludePdo>#x1606</ExcludePdo>
+						<Entry Name="Position" Index="#x7010" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Velocity" Index="#x1604" InOut="1" Flags="#x0010" SyncMan="2">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<ExcludePdo>#x1606</ExcludePdo>
+						<Entry Name="Velocity" Index="#x7010" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Control compact" Index="#x1605" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1606</ExcludePdo>
+						<Entry Name="Control__Execute" Index="#x7020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Emergency stop" Index="#x7020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000E}">ARRAY [0..13] OF BIT</Type>
+						</Entry>
+						<Entry Name="Target position" Index="#x7020" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Control" Index="#x1606" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<Entry Name="Control__Execute" Index="#x7020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Emergency stop" Index="#x7020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000E}">ARRAY [0..13] OF BIT</Type>
+						</Entry>
+						<Entry Name="Target position" Index="#x7020" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Velocity" Index="#x7020" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+						<Entry Name="Start type" Index="#x7020" Sub="#x22">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Acceleration" Index="#x7020" Sub="#x23">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Deceleration" Index="#x7020" Sub="#x24">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Control 2" Index="#x1607" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000002}">ARRAY [0..1] OF BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable auto start" Index="#x7021" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000D}">ARRAY [0..12] OF BIT</Type>
+						</Entry>
+						<Entry Name="Target position" Index="#x7021" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Velocity" Index="#x7021" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+						<Entry Name="Start type" Index="#x7021" Sub="#x22">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Acceleration" Index="#x7021" Sub="#x23">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Deceleration" Index="#x7021" Sub="#x24">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<CoeProfile ProfileNo="33493897" DisplayName="Stepper interface"/>
+					<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
+					<CoeProfile ProfileNo="46142345" DisplayName="Positioning interfa"/>
+				</EtherCAT>
+			</Box>
+			<Box Id="9" BoxType="9099" BoxFlags="#x00000020">
+				<Name>Term 9 (EL7201)</Name>
+				<ImageId>1004</ImageId>
+				<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CfgModeSafeOp="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1c213052" RevisionNo="#x00150000" InfoDataAddr="true" InfoDataSoeDS401="true" InfoDataDcTimes="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7201 1Ch. MDP742 Servo motor output stage (50V, 4A)" Desc="EL7201" PortABoxInfo="#x01000008">
+					<SyncMan>001080002600010001000000500080008000001026010000</SyncMan>
+					<SyncMan>801080002200010002000000500080008000801022010000</SyncMan>
+					<SyncMan>001106002400010003000000000000000600001124010000</SyncMan>
+					<SyncMan>801106002000010004000000000000000600801120010000</SyncMan>
+					<Fmmu>0000000000000000001100020100000001000000000000000000000000000000</Fmmu>
+					<Fmmu>0000000000000000801100010100000002000000000000000000000000000000</Fmmu>
+					<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
+					<BootStrapData>0010f400f410f400</BootStrapData>
+					<DcData>000700000000000030750000e80300000100ffff000000000000000000000000</DcData>
+					<DcMode>4443000000000000000000000000000044432d53796e6368726f6e0000000000000000000000000000000000000000000000000030750000e8030000ffff00070100000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<MBoxUserCmdData>004003000c0000000000000003000000000000000000000000000000000000002081f001040000000000150000</MBoxUserCmdData>
+					<Pdo Name="FB Position" Index="#x1a00" Flags="#x0010" SyncMan="3">
+						<Entry Name="Position" Index="#x6000" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Statusword" Index="#x1a01" Flags="#x0010" SyncMan="3">
+						<Entry Name="Statusword" Index="#x6010" Sub="#x01">
+							<Type>UINT</Type>
+							<Comment><![CDATA[Bit 0 : Ready to switch on
+Bit 1 : Switched on
+Bit 2 : Operation enabled
+Bit 3 : Fault
+Bit 4 : reserved
+Bit 5 : reserved
+Bit 6 : Switch on disabled
+Bit 7 : Warning
+Bit 8 + 9 : reserved
+Bit 10 : TxPDOToggle
+Bit 11 : Internal limit active
+Bit 12 : Drive follows the command value
+Bit 13 : Input cycle counter
+Bit 14 - 15 : reserved]]></Comment>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Velocity actual value" Index="#x1a02" Flags="#x0010">
+						<Entry Name="Velocity actual value" Index="#x6010" Sub="#x07">
+							<Type>DINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Torque actual value" Index="#x1a03" Flags="#x0010">
+						<Entry Name="Torque actual value" Index="#x6010" Sub="#x08">
+							<Type>INT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Info data 1" Index="#x1a04" Flags="#x0010">
+						<Entry Name="Info data 1" Index="#x6010" Sub="#x12">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Info data 2" Index="#x1a05" Flags="#x0010">
+						<Entry Name="Info data 2" Index="#x6010" Sub="#x13">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Following error actual value" Index="#x1a06" Flags="#x0010">
+						<Entry Name="Following error actual value" Index="#x6010" Sub="#x06">
+							<Type>DINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="FB Status" Index="#x1a0c" Flags="#x0010">
+						<Entry Name="FB Status__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000D}">ARRAY [0..12] OF BIT</Type>
+						</Entry>
+						<Entry Name="FB Status__TxPDO State" Index="#x6000" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="FB Status__Input Cycle Counter" Index="#x6000" Sub="#x0f">
+							<Type>BIT2</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Controlword" Index="#x1600" InOut="1" Flags="#x0010" SyncMan="2">
+						<Entry Name="Controlword" Index="#x7010" Sub="#x01">
+							<Type>UINT</Type>
+							<Comment><![CDATA[Bit 0 : Switch on
+Bit 1 : Enable voltage
+Bit 2 : reserved
+Bit 3 : Enable operation
+Bit 4 - 6 : reserved
+Bit 7 : Fault reset
+Bit 8 - 15 : reserved]]></Comment>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Target velocity" Index="#x1601" InOut="1" Flags="#x0010" SyncMan="2">
+						<Entry Name="Target velocity" Index="#x7010" Sub="#x06">
+							<Type>DINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Target torque" Index="#x1602" InOut="1" Flags="#x0010">
+						<Entry Name="Target torque" Index="#x7010" Sub="#x09">
+							<Type>INT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Commutation angle" Index="#x1603" InOut="1" Flags="#x0010">
+						<Entry Name="Commutation angle" Index="#x7010" Sub="#x0e">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Torque limitation" Index="#x1604" InOut="1" Flags="#x0010">
+						<Entry Name="Torque limitation" Index="#x7010" Sub="#x0b">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Torque offset" Index="#x1605" InOut="1" Flags="#x0010">
+						<Entry Name="Torque offset" Index="#x7010" Sub="#x0a">
+							<Type>INT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="DRV Target position" Index="#x1606" InOut="1" Flags="#x0010">
+						<Entry Name="Target position" Index="#x7010" Sub="#x05">
+							<Type>DINT</Type>
+						</Entry>
+					</Pdo>
+					<CoeProfile ProfileNo="33624969" DisplayName="Servo interface"/>
+					<CoeProfile ProfileNo="48632713" DisplayName="Servo interface"/>
+				</EtherCAT>
+			</Box>
+			<Box Id="10" BoxType="9099" BoxFlags="#x00000020">
+				<Name>Term 10 (EL7037)</Name>
+				<ImageId>1004</ImageId>
+				<EtherCAT SlaveType="2" PdiType="#x0405" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="39" FoeType="1" VendorId="#x00000002" ProductCode="#x1b7d3052" RevisionNo="#x00130000" InfoDataAddr="true" InfoDataSoeDS401="true" RepeatSupport="true" SetFrameRepeatTime="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL7037 1Ch. Stepper motor output stage (24V, 1.5A)" Desc="EL7037" PortABoxInfo="#x01000009">
+					<SyncMan>001080002600010001000000400080008000001026010000</SyncMan>
+					<SyncMan>801080002200010002000000400080008000801022010000</SyncMan>
+					<SyncMan>001108002400010003000000000000000800001124010000</SyncMan>
+					<SyncMan>801108002000010004000000000000000800801120010000</SyncMan>
+					<Fmmu>0000000000000000001100020100000001000000000000000000000000000000</Fmmu>
+					<Fmmu>0000000000000000801100010100000002000000000000000000000000000000</Fmmu>
+					<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
+					<BootStrapData>0010f400f410f400</BootStrapData>
+					<DcMode>53796e6368726f6e00000000000000004672656552756e2f534d2d53796e6368726f6e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<DcMode>4443000000000000000000000000000044432d53796e6368726f6e000000000000000000000000000000000000000000000000000000000000000000000000030100000000000000000000000000000000000000000000000000000000000000</DcMode>
+					<MBoxUserCmdData>004003000c0000000000000003000000000000000000000000000000000000002081f001040000000000130000</MBoxUserCmdData>
+					<MBoxUserCmdData>004003000a00000000000000030010000000000000000000000000000000000020f3100502000000010000</MBoxUserCmdData>
+					<Pdo Name="ENC Status compact" Index="#x1a00" Flags="#x0010" SyncMan="3">
+						<ExcludePdo>#x1a01</ExcludePdo>
+						<Entry Name="Status__Latch C valid" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Latch extern valid" Index="#x6000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Set counter done" Index="#x6000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter underflow" Index="#x6000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter overflow" Index="#x6000" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000002}">ARRAY [0..1] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Extrapolation stall" Index="#x6000" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input A" Index="#x6000" Sub="#x09">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input B" Index="#x6000" Sub="#x0a">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input C" Index="#x6000" Sub="#x0b">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of extern latch" Index="#x6000" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6000" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6000" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Counter value" Index="#x6000" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Latch value" Index="#x6000" Sub="#x12">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Status" Index="#x1a01" Flags="#x0010">
+						<ExcludePdo>#x1a00</ExcludePdo>
+						<Entry Name="Status__Latch C valid" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Latch extern valid" Index="#x6000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Set counter done" Index="#x6000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter underflow" Index="#x6000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Counter overflow" Index="#x6000" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000002}">ARRAY [0..1] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Extrapolation stall" Index="#x6000" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input A" Index="#x6000" Sub="#x09">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input B" Index="#x6000" Sub="#x0a">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of input C" Index="#x6000" Sub="#x0b">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Status of extern latch" Index="#x6000" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6000" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6000" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Counter value" Index="#x6000" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Latch value" Index="#x6000" Sub="#x12">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Timest. compact" Index="#x1a02" Flags="#x0010">
+						<Entry Name="Timestamp" Index="#x6000" Sub="#x16">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Status" Index="#x1a03" Flags="#x0010" SyncMan="3">
+						<Entry Name="Status__Ready to enable" Index="#x6010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Ready" Index="#x6010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Warning" Index="#x6010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Error" Index="#x6010" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Moving positive" Index="#x6010" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Moving negative" Index="#x6010" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Torque reduced" Index="#x6010" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Motor stall" Index="#x6010" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000003}">ARRAY [0..2] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__Digital input 1" Index="#x6010" Sub="#x0c">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Digital input 2" Index="#x6010" Sub="#x0d">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Sync error" Index="#x6010" Sub="#x0e">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000001}">ARRAY [0..0] OF BIT</Type>
+						</Entry>
+						<Entry Name="Status__TxPDO Toggle" Index="#x6010" Sub="#x10">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Synchron info data" Index="#x1a04" Flags="#x0010">
+						<Entry Name="Info data 1" Index="#x6010" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Info data 2" Index="#x6010" Sub="#x12">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Motor load" Index="#x1a05" Flags="#x0010">
+						<Entry Name="Motor load" Index="#x6010" Sub="#x13">
+							<Type>INT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Status compact" Index="#x1a06" Flags="#x0010">
+						<ExcludePdo>#x1a07</ExcludePdo>
+						<Entry Name="Status__Busy" Index="#x6020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__In-Target" Index="#x6020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Warning" Index="#x6020" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Error" Index="#x6020" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Calibrated" Index="#x6020" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Accelerate" Index="#x6020" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Decelerate" Index="#x6020" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Ready to execute" Index="#x6020" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Status" Index="#x1a07" Flags="#x0010">
+						<ExcludePdo>#x1a06</ExcludePdo>
+						<Entry Name="Status__Busy" Index="#x6020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__In-Target" Index="#x6020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Warning" Index="#x6020" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Error" Index="#x6020" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Calibrated" Index="#x6020" Sub="#x05">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Accelerate" Index="#x6020" Sub="#x06">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Decelerate" Index="#x6020" Sub="#x07">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__Ready to execute" Index="#x6020" Sub="#x08">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Status__">
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="Actual position" Index="#x6020" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Actual velocity" Index="#x6020" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+						<Entry Name="Actual drive time" Index="#x6020" Sub="#x22">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Internal position" Index="#x1a08" Flags="#x0010">
+						<Entry Name="Internal position" Index="#x6010" Sub="#x14">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM External position" Index="#x1a09" Flags="#x0010">
+						<Entry Name="External position" Index="#x6010" Sub="#x15">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Actual position lag" Index="#x1a0a" Flags="#x0010">
+						<Entry Name="Actual position lag" Index="#x6020" Sub="#x23">
+							<Type>DINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Control compact" Index="#x1600" InOut="1" Flags="#x0010" SyncMan="2">
+						<ExcludePdo>#x1601</ExcludePdo>
+						<Entry Name="Control__Enable latch C" Index="#x7000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on positive edge" Index="#x7000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Set counter" Index="#x7000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on negative edge" Index="#x7000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000C}">ARRAY [0..11] OF BIT</Type>
+						</Entry>
+						<Entry Name="Set counter value" Index="#x7000" Sub="#x11">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="ENC Control" Index="#x1601" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1600</ExcludePdo>
+						<Entry Name="Control__Enable latch C" Index="#x7000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on positive edge" Index="#x7000" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Set counter" Index="#x7000" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable latch extern on negative edge" Index="#x7000" Sub="#x04">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000C}">ARRAY [0..11] OF BIT</Type>
+						</Entry>
+						<Entry Name="Set counter value" Index="#x7000" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Control" Index="#x1602" InOut="1" Flags="#x0010" SyncMan="2">
+						<Entry Name="Control__Enable" Index="#x7010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Reset" Index="#x7010" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Reduce torque" Index="#x7010" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000008}">ARRAY [0..0] OF BYTE</Type>
+						</Entry>
+						<Entry Name="Control__Digital output 1" Index="#x7010" Sub="#x0c">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000004}">ARRAY [0..3] OF BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Position" Index="#x1603" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<ExcludePdo>#x1606</ExcludePdo>
+						<Entry Name="Position" Index="#x7010" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="STM Velocity" Index="#x1604" InOut="1" Flags="#x0010" SyncMan="2">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<ExcludePdo>#x1606</ExcludePdo>
+						<Entry Name="Velocity" Index="#x7010" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Control compact" Index="#x1605" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1606</ExcludePdo>
+						<Entry Name="Control__Execute" Index="#x7020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Emergency stop" Index="#x7020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000E}">ARRAY [0..13] OF BIT</Type>
+						</Entry>
+						<Entry Name="Target position" Index="#x7020" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Control" Index="#x1606" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<Entry Name="Control__Execute" Index="#x7020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__Emergency stop" Index="#x7020" Sub="#x02">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000E}">ARRAY [0..13] OF BIT</Type>
+						</Entry>
+						<Entry Name="Target position" Index="#x7020" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Velocity" Index="#x7020" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+						<Entry Name="Start type" Index="#x7020" Sub="#x22">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Acceleration" Index="#x7020" Sub="#x23">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Deceleration" Index="#x7020" Sub="#x24">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="POS Control 2" Index="#x1607" InOut="1" Flags="#x0010">
+						<ExcludePdo>#x1603</ExcludePdo>
+						<ExcludePdo>#x1604</ExcludePdo>
+						<ExcludePdo>#x1605</ExcludePdo>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-002000000002}">ARRAY [0..1] OF BIT</Type>
+						</Entry>
+						<Entry Name="Control__Enable auto start" Index="#x7021" Sub="#x03">
+							<Type>BIT</Type>
+						</Entry>
+						<Entry Name="Control__">
+							<Type GUID="{18071995-0000-0000-0000-00200000000D}">ARRAY [0..12] OF BIT</Type>
+						</Entry>
+						<Entry Name="Target position" Index="#x7021" Sub="#x11">
+							<Type>UDINT</Type>
+						</Entry>
+						<Entry Name="Velocity" Index="#x7021" Sub="#x21">
+							<Type>INT</Type>
+						</Entry>
+						<Entry Name="Start type" Index="#x7021" Sub="#x22">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Acceleration" Index="#x7021" Sub="#x23">
+							<Type>UINT</Type>
+						</Entry>
+						<Entry Name="Deceleration" Index="#x7021" Sub="#x24">
+							<Type>UINT</Type>
+						</Entry>
+					</Pdo>
+					<CoeProfile ProfileNo="33493897" DisplayName="Stepper interface"/>
+					<CoeProfile ProfileNo="46076809" DisplayName="Stepper interface"/>
+					<CoeProfile ProfileNo="46142345" DisplayName="Positioning interfa"/>
+				</EtherCAT>
+			</Box>
+			<Box Id="11" BoxType="9099">
+				<Name>Term 11 (EL1004)</Name>
+				<ImageId>7</ImageId>
+				<EtherCAT SlaveType="1" PdiType="#x0104" CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x03ec3052" RevisionNo="#x00120000" RepeatSupport="true" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL1004 4Ch. Dig. Input 24V, 3ms" Desc="EL1004" PortABoxInfo="#x0100000a">
+					<SyncMan>001001000000010004000000000000000100001000010000</SyncMan>
+					<Fmmu>0000000000000000001000010100000002000000000000000000000000000000</Fmmu>
+					<Pdo Name="Channel 1" Index="#x1a00" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6000" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 2" Index="#x1a01" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6010" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 3" Index="#x1a02" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6020" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+					<Pdo Name="Channel 4" Index="#x1a03" Flags="#x0011" SyncMan="0">
+						<Entry Name="Input" Index="#x6030" Sub="#x01">
+							<Type>BIT</Type>
+						</Entry>
+					</Pdo>
+				</EtherCAT>
+			</Box>
+			<Box Id="12" BoxType="9099">
+				<Name>Term 12 (EL9011)</Name>
+				<ImageId>1005</ImageId>
+				<EtherCAT CycleMBoxPollingTime="0" VendorId="#x00000002" ProductCode="#x23333050" InfoDataState="false" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL9011 End Terminal" Desc="EL9011" PortABoxInfo="#x0100000b"/>
+			</Box>
+		</Box>
+		<EtherCAT DcSyncMode="3"/>
+	</Device>
+</TcSmItem>

--- a/solution/_Config/IO/PNOZ (EtherCAT).xti
+++ b/solution/_Config/IO/PNOZ (EtherCAT).xti
@@ -1,0 +1,576 @@
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.62" ClassName="CDevEtherCATDef" SubType="111">
+	<ImageDatas>
+		<ImageData Id="1000">424de6000000000000007600000028000000100000000e00000001000400000000007000000000000000000000001000000000000000000000001198cb0097a199001c6574005ea5be00596374001487b2005fc9ed0037635f008bd7ed00ffffff0009433f009ebbc0007283830022b4eb003f4d4a00a8ff8aac338338caa8558aa60000004aa82d8aa1116611eaa8ff8aa611e1117aa8ff8aa74777779aa82d8aa77777479aa8c28aa47774579aa8bb8aa44444279aa8bb8aa4dddd2c9aa8bb8aa444442c9aafbb8aa41eeeee7aafbb8aa13eeeee7aaf00faa1111111eaad88daa13333334a</ImageData>
+	</ImageDatas>
+	<Device Id="4" DevType="111" DevFlags="#x0003" AmsPort="28676" AmsNetId="172.30.41.145.5.1" RemoteName="PNOZ (EtherCAT)" InfoImageId="6">
+		<Name>__FILENAME__</Name>
+		<AddressInfo>
+			<Pnp>
+				<DeviceDesc>Local Area Connection 2 (TwinCAT-Intel PCI Ethernet</DeviceDesc>
+				<DeviceName>\DEVICE\{225F8895-47D0-450D-B6DF-ACF28535D923}</DeviceName>
+				<DeviceData>000105248854</DeviceData>
+			</Pnp>
+		</AddressInfo>
+		<Image Id="5" AddrType="9" ImageType="3">
+			<Name>Image</Name>
+		</Image>
+		<Box Id="13" BoxType="9099" BoxFlags="#x00000020">
+			<Name>Box (PNOZ m ES EtherCAT)</Name>
+			<ImageId>1000</ImageId>
+			<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="47" VendorId="#x00000569" ProductCode="#x000bc828" RevisionNo="#x00020002" InfoDataAddr="true" TimeoutStateChange1="32000" TimeoutStateChange2="32000" PortPhys="17" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="PNOZ m ES EtherCAT (2.2)" Desc="PNOZ m ES EtherCAT" SmPdoVariables="true" PortABoxInfo="#x00ffffff">
+				<SyncMan>001cc000260001000100000032000001c000001c26010000</SyncMan>
+				<SyncMan>001ec000220001000200000032000001c000001e22010000</SyncMan>
+				<SyncMan>001113006400010003000000010080001300001164010000</SyncMan>
+				<SyncMan>001320002000010004000000000000012000001320010000</SyncMan>
+				<Fmmu>0000000000000000001100020100000001000000000000000000000000000000</Fmmu>
+				<Fmmu>0000000000000000001300010100000002000000000000000000000000000000</Fmmu>
+				<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
+				<Pdo Name="TxPDO" Index="#x1a00" Flags="#x0000" SyncMan="3">
+					<Entry Name="Virtual Output 000...007" Index="#x2000" Sub="#x01">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 008...015" Index="#x2000" Sub="#x02">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 016...023" Index="#x2000" Sub="#x03">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 024...031" Index="#x2000" Sub="#x04">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 032...039" Index="#x2000" Sub="#x05">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 040...047" Index="#x2000" Sub="#x06">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 048...055" Index="#x2000" Sub="#x07">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 056...063" Index="#x2000" Sub="#x08">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 064...071" Index="#x2000" Sub="#x09">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 072...079" Index="#x2000" Sub="#x0a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 080...087" Index="#x2000" Sub="#x0b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 088...095" Index="#x2000" Sub="#x0c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 096...103" Index="#x2000" Sub="#x0d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 104...111" Index="#x2000" Sub="#x0e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 112...119" Index="#x2000" Sub="#x0f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 120...127" Index="#x2000" Sub="#x10">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="LED State" Index="#x2000" Sub="#x11">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Table Number" Index="#x2000" Sub="#x12">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Number" Index="#x2000" Sub="#x13">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 00" Index="#x2000" Sub="#x14">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 01" Index="#x2000" Sub="#x15">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 02" Index="#x2000" Sub="#x16">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 03" Index="#x2000" Sub="#x17">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 04" Index="#x2000" Sub="#x18">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 05" Index="#x2000" Sub="#x19">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 06" Index="#x2000" Sub="#x1a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 07" Index="#x2000" Sub="#x1b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 08" Index="#x2000" Sub="#x1c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 09" Index="#x2000" Sub="#x1d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 10" Index="#x2000" Sub="#x1e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 11" Index="#x2000" Sub="#x1f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Byte 12" Index="#x2000" Sub="#x20">
+						<Type>USINT</Type>
+					</Entry>
+				</Pdo>
+				<Pdo Name="TxPDO" Index="#x1a01" Flags="#x0000">
+					<Entry Name="Virtual Output 000...007" Index="#x2000" Sub="#x01">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 008...015" Index="#x2000" Sub="#x02">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 016...023" Index="#x2000" Sub="#x03">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 024...031" Index="#x2000" Sub="#x04">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 032...039" Index="#x2000" Sub="#x05">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 040...047" Index="#x2000" Sub="#x06">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 048...055" Index="#x2000" Sub="#x07">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 056...063" Index="#x2000" Sub="#x08">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 064...071" Index="#x2000" Sub="#x09">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 072...079" Index="#x2000" Sub="#x0a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 080...087" Index="#x2000" Sub="#x0b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 088...095" Index="#x2000" Sub="#x0c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 096...103" Index="#x2000" Sub="#x0d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 104...111" Index="#x2000" Sub="#x0e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 112...119" Index="#x2000" Sub="#x0f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Output 120...127" Index="#x2000" Sub="#x10">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="LED State" Index="#x2000" Sub="#x11">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Input 00...07" Index="#x2001" Sub="#x01">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Input 08...15" Index="#x2001" Sub="#x02">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Input 16...23" Index="#x2001" Sub="#x03">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Input 24...31" Index="#x2001" Sub="#x04">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Output 00...07" Index="#x2001" Sub="#x05">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Output 08...15" Index="#x2001" Sub="#x06">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Output 16...23" Index="#x2001" Sub="#x07">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Base Module Output 24...31" Index="#x2001" Sub="#x08">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Input 00...07" Index="#x2001" Sub="#x49">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Input 08...15" Index="#x2001" Sub="#x4a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Input 16...23" Index="#x2001" Sub="#x4b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Input 24...31" Index="#x2001" Sub="#x4c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Output 00...07" Index="#x2001" Sub="#x4d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Output 08...15" Index="#x2001" Sub="#x4e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Output 16...23" Index="#x2001" Sub="#x4f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Right Output 24...31" Index="#x2001" Sub="#x50">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Input 00...07" Index="#x2002" Sub="#x01">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Input 08...15" Index="#x2002" Sub="#x02">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Input 16...23" Index="#x2002" Sub="#x03">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Input 24...31" Index="#x2002" Sub="#x04">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Output 00...07" Index="#x2002" Sub="#x05">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Output 08...15" Index="#x2002" Sub="#x06">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Output 16...23" Index="#x2002" Sub="#x07">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Right Output 24...31" Index="#x2002" Sub="#x08">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Input 00...07" Index="#x2002" Sub="#x25">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Input 08...15" Index="#x2002" Sub="#x26">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Input 16...23" Index="#x2002" Sub="#x27">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Input 24...31" Index="#x2002" Sub="#x28">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Output 00...07" Index="#x2002" Sub="#x29">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Output 08...15" Index="#x2002" Sub="#x2a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Output 16...23" Index="#x2002" Sub="#x2b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Right Output 24...31" Index="#x2002" Sub="#x2c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Input 00...07" Index="#x2002" Sub="#x49">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Input 08...15" Index="#x2002" Sub="#x4a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Input 16...23" Index="#x2002" Sub="#x4b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Input 24...31" Index="#x2002" Sub="#x4c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Output 00...07" Index="#x2002" Sub="#x4d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Output 08...15" Index="#x2002" Sub="#x4e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Output 16...23" Index="#x2002" Sub="#x4f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 04 Right Output 24...31" Index="#x2002" Sub="#x50">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Input 00...07" Index="#x2007" Sub="#x01">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Input 08...15" Index="#x2007" Sub="#x02">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Input 16...23" Index="#x2007" Sub="#x03">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Input 24...31" Index="#x2007" Sub="#x04">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Output 00...07" Index="#x2007" Sub="#x05">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Output 08...15" Index="#x2007" Sub="#x06">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Output 16...23" Index="#x2007" Sub="#x07">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 01 Left Output 24...31" Index="#x2007" Sub="#x08">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Input 00...07" Index="#x2007" Sub="#x25">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Input 08...15" Index="#x2007" Sub="#x26">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Input 16...23" Index="#x2007" Sub="#x27">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Input 24...31" Index="#x2007" Sub="#x28">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Output 00...07" Index="#x2007" Sub="#x29">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Output 08...15" Index="#x2007" Sub="#x2a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Output 16...23" Index="#x2007" Sub="#x2b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 02 Left Output 24...31" Index="#x2007" Sub="#x2c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Input 00...07" Index="#x2007" Sub="#x49">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Input 08...15" Index="#x2007" Sub="#x4a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Input 16...23" Index="#x2007" Sub="#x4b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Input 24...31" Index="#x2007" Sub="#x4c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Output 00...07" Index="#x2007" Sub="#x4d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Output 08...15" Index="#x2007" Sub="#x4e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Output 16...23" Index="#x2007" Sub="#x4f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Expansion Module 03 Left Output 24...31" Index="#x2007" Sub="#x50">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 001 H" Index="#x200a" Sub="#x01">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 001 L" Index="#x200a" Sub="#x02">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 002 H" Index="#x200a" Sub="#x03">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 002 L" Index="#x200a" Sub="#x04">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 003 H" Index="#x200a" Sub="#x05">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 003 L" Index="#x200a" Sub="#x06">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 004 H" Index="#x200a" Sub="#x07">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 004 L" Index="#x200a" Sub="#x08">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 005 H" Index="#x200a" Sub="#x09">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 005 L" Index="#x200a" Sub="#x0a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 006 H" Index="#x200a" Sub="#x0b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 006 L" Index="#x200a" Sub="#x0c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 007 H" Index="#x200a" Sub="#x0d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 007 L" Index="#x200a" Sub="#x0e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 008 H" Index="#x200a" Sub="#x0f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 008 L" Index="#x200a" Sub="#x10">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 009 H" Index="#x200a" Sub="#x11">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 009 L" Index="#x200a" Sub="#x12">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 010 H" Index="#x200a" Sub="#x13">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 010 L" Index="#x200a" Sub="#x14">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 011 H" Index="#x200a" Sub="#x15">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 011 L" Index="#x200a" Sub="#x16">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 012 H" Index="#x200a" Sub="#x17">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 012 L" Index="#x200a" Sub="#x18">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 013 H" Index="#x200a" Sub="#x19">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 013 L" Index="#x200a" Sub="#x1a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 014 H" Index="#x200a" Sub="#x1b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 014 L" Index="#x200a" Sub="#x1c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 015 H" Index="#x200a" Sub="#x1d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 015 L" Index="#x200a" Sub="#x1e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 016 H" Index="#x200a" Sub="#x1f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 016 L" Index="#x200a" Sub="#x20">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 017 H" Index="#x200a" Sub="#x21">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 017 L" Index="#x200a" Sub="#x22">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 018 H" Index="#x200a" Sub="#x23">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 018 L" Index="#x200a" Sub="#x24">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 019 H" Index="#x200a" Sub="#x25">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 019 L" Index="#x200a" Sub="#x26">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 020 H" Index="#x200a" Sub="#x27">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 020 L" Index="#x200a" Sub="#x28">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 021 H" Index="#x200a" Sub="#x29">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 021 L" Index="#x200a" Sub="#x2a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 022 H" Index="#x200a" Sub="#x2b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 022 L" Index="#x200a" Sub="#x2c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 023 H" Index="#x200a" Sub="#x2d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 023 L" Index="#x200a" Sub="#x2e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Diagnostic Word 024 H" Index="#x200a" Sub="#x2f">
+						<Type>USINT</Type>
+					</Entry>
+				</Pdo>
+				<Pdo Name="RxPDO" Index="#x1600" InOut="1" Flags="#x0000" SyncMan="2">
+					<Entry Name="Virtual Input 000...007" Index="#x2100" Sub="#x01">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 008...015" Index="#x2100" Sub="#x02">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 016...023" Index="#x2100" Sub="#x03">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 024...031" Index="#x2100" Sub="#x04">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 032...039" Index="#x2100" Sub="#x05">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 040...047" Index="#x2100" Sub="#x06">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 048...055" Index="#x2100" Sub="#x07">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 056...063" Index="#x2100" Sub="#x08">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 064...071" Index="#x2100" Sub="#x09">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 072...079" Index="#x2100" Sub="#x0a">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 080...087" Index="#x2100" Sub="#x0b">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 088...095" Index="#x2100" Sub="#x0c">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 096...103" Index="#x2100" Sub="#x0d">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 104...111" Index="#x2100" Sub="#x0e">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 112...119" Index="#x2100" Sub="#x0f">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Virtual Input 120...127" Index="#x2100" Sub="#x10">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Not Used 017" Index="#x2100" Sub="#x11">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Table Number" Index="#x2100" Sub="#x12">
+						<Type>USINT</Type>
+					</Entry>
+					<Entry Name="Segment Number" Index="#x2100" Sub="#x13">
+						<Type>USINT</Type>
+					</Entry>
+				</Pdo>
+			</EtherCAT>
+		</Box>
+		<EtherCAT/>
+	</Device>
+</TcSmItem>

--- a/solution/tc_project_app/DUTs/Safety/E_MCCSafetyFunctions.TcDUT
+++ b/solution/tc_project_app/DUTs/Safety/E_MCCSafetyFunctions.TcDUT
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="E_MCCSafetyFunctions" Id="{67cba4a1-d914-0ba8-3f98-b5150a554ddf}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_MCCSafetyFunctions :
+(
+    SF3_0_NONE := 0,
+    SF3_1_EStop := 1,
+    SF3_2_PSSAccess := 2,
+    SF3_3_RestartPreventionExp := 3,
+    SF3_4_RestartPreventionOpt := 4,
+    SF3_5_StopMiddleFocus := 5,
+    SF3_6_EnableMiddleFocus := 6,
+    SF3_7_SafeTorqueOff := 7,
+    SF3_17_E_LED_STATE := 17
+);
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/solution/tc_project_app/DUTs/Safety/MCC_SafetyFunctions/ST_SF3_1_ESTOP.TcDUT
+++ b/solution/tc_project_app/DUTs/Safety/MCC_SafetyFunctions/ST_SF3_1_ESTOP.TcDUT
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="ST_SF3_1_ESTOP" Id="{cee9a2af-de4d-0f20-1f26-6c0fafd62275}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE ST_SF3_1_ESTOP :
+STRUCT
+    bSI_ES_EXP : BOOL;
+    bSI_ES_OPT : BOOL;
+    bSI_ES_EXT : BOOL;
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/solution/tc_project_app/DUTs/Safety/MCC_SafetyFunctions/ST_SF3_2_PSS_ACCESS.TcDUT
+++ b/solution/tc_project_app/DUTs/Safety/MCC_SafetyFunctions/ST_SF3_2_PSS_ACCESS.TcDUT
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="ST_SF3_2_PSS_ACCESS" Id="{7309269c-1ae7-0ced-290a-1ea86b6a8482}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE ST_SF3_2_PSS_ACCESS :
+STRUCT
+    bSI_PSS_ACCESS : BOOL;
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/solution/tc_project_app/DUTs/Safety/MCC_SafetyFunctions/ST_SF3_3_RESTART_PREVENTION_EXP.TcDUT
+++ b/solution/tc_project_app/DUTs/Safety/MCC_SafetyFunctions/ST_SF3_3_RESTART_PREVENTION_EXP.TcDUT
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="ST_SF3_3_RESTART_PREVENTION_EXP" Id="{a46a440a-a956-0527-0f0f-fdc0940ba3a1}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE ST_SF3_3_RESTART_PREVENTION_EXP :
+STRUCT
+    bSI_RESET_EXP : BOOL;
+    bSI_PSS_ACCESS : BOOL;
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/solution/tc_project_app/DUTs/Safety/ST_MCCSafetyFunctions.TcDUT
+++ b/solution/tc_project_app/DUTs/Safety/ST_MCCSafetyFunctions.TcDUT
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="ST_MCCSafetyFunctions" Id="{a14bb73e-e071-0777-120d-26666a0ac858}">
+    <Declaration><![CDATA[TYPE ST_MCCSafetyFunctions :
+STRUCT
+    aSafetyFunction : ARRAY[1..GVL_SafetyIO.UPPER_BOUND_SF_INPUT] OF ST_SafetyFunction;
+    stLEDState : ST_LEDState;
+
+    stSF31EStop : ST_SF3_1_EStop;
+    stSF32PSSAccess : ST_SF3_2_PSS_ACCESS;
+    stSF33RestartPreventionExp : ST_SF3_3_RESTART_PREVENTION_EXP;
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -27,8 +27,8 @@ VAR
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
 
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
-	
-	// Motion Safety
+
+    // Motion Safety
     fbMotionSafety : FB_MotionSafety;
     stMCCSafetyFunctions : ST_MCCSafetyFunctions;
 END_VAR

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -41,7 +41,8 @@ END_VAR
       <ST><![CDATA[POSITION_RECOVERY();
 PROG();
 AXES();
-SAFETY();]]></ST>
+SAFETY();
+]]></ST>
     </Implementation>
     <Folder Name="POSITION_RECOVERY" Id="{3561f6ef-e145-4ed3-9839-f17334bd2d97}" />
     <Action Name="AXES" Id="{7eb32732-9b53-4934-8cd9-20ba971dd8ff}">

--- a/solution/tc_project_app/POUs/MAIN.TcPOU
+++ b/solution/tc_project_app/POUs/MAIN.TcPOU
@@ -27,6 +27,10 @@ VAR
     fbGetDeviceIdentification: FB_GetDeviceIdentificationEx;
 
     nTestNum: UINT :=0 ; //Variable used in ESS's FAT_SAT_tools scripts to keep track of the test number
+	
+	// Motion Safety
+    fbMotionSafety : FB_MotionSafety;
+    stMCCSafetyFunctions : ST_MCCSafetyFunctions;
 END_VAR
 
 VAR PERSISTENT
@@ -37,7 +41,7 @@ END_VAR
       <ST><![CDATA[POSITION_RECOVERY();
 PROG();
 AXES();
-]]></ST>
+SAFETY();]]></ST>
     </Implementation>
     <Folder Name="POSITION_RECOVERY" Id="{3561f6ef-e145-4ed3-9839-f17334bd2d97}" />
     <Action Name="AXES" Id="{7eb32732-9b53-4934-8cd9-20ba971dd8ff}">
@@ -291,6 +295,24 @@ IF bRestoreExecute AND NOT bPositionRestoreDone THEN
             END_FOR
     END_CASE
 END_IF
+]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="SAFETY" Id="{8e22ca14-5d6c-08d6-2145-dd69cdd85f95}">
+      <Implementation>
+        <ST><![CDATA[// -----------------------------------------------------------------------------
+// Calls FB_MotionSafety to read the raw PNOZ EtherCAT input data, format it into
+// fbMotionSafety.stECATIn, and link each safety function into stMCCSafetyFunctions.
+//
+// Safety function byte mapping is defined in E_MCCSafetyFunction.
+// -----------------------------------------------------------------------------
+
+fbMotionSafety(bEnableSafety := TRUE, stMCCSafetyFunctions := stMCCSafetyFunctions);
+
+// LOGIC SPECIFIC TO THIS CABINET, Placeholder, WIP
+// MCC-specific safety rules/effects should be added below.
+
+fbMotionSafety.mWriteECATOutput();
 ]]></ST>
       </Implementation>
     </Action>


### PR DESCRIPTION
This PR includes changes made MAIN related to SAFETY, the idea is that SAFETY functions from the safety controller PNOZmulti 2 will need to be configured by the programmer in TwinCAT depending on the instruments safety requirements and the specific safety functions written in the safety controller. 

E_MMCSafetyFunctions is just an example of Safety Functions that are expected, furthermore MCC_SafetyFunctions includes structs describing what each incoming bit will represents. 

For changes made to tc_mca_std_lib: [https://github.com/EuropeanSpallationSource/tc_mca_std_lib/pull/53](url)
