### PR TITLE
MBP-391: Homing rework

### DIFF
--- a/solution/tc_project_app/tc_project_app.plcproj
+++ b/solution/tc_project_app/tc_project_app.plcproj
@@ -127,7 +127,16 @@
     <Compile Include="tc_mca_std_lib\DUTs\E_CustomErrorIds.TcTLEO">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="tc_mca_std_lib\DUTs\E_DetectionMode.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="tc_mca_std_lib\DUTs\E_EncoderRefSys.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="tc_mca_std_lib\DUTs\E_ExternalBrake.TcTLEO">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="tc_mca_std_lib\DUTs\E_HomeSequenceState.TcDUT">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="tc_mca_std_lib\DUTs\E_HomingRoutines.TcTLEO">
@@ -137,9 +146,6 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="tc_mca_std_lib\DUTs\E_MonitorLed.TcDUT">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="tc_mca_std_lib\DUTs\E_RestorePosition.TcDUT">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="tc_mca_std_lib\DUTs\E_SlitSoftLimits.TcDUT">


### PR DESCRIPTION
Add new enums introduced in lates homing rework in tc_mca_std_lib.
To test check out to branch and rebuild.